### PR TITLE
feat: add GH_TOKEN to check-semver-labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,6 +36,12 @@ group:releases:
   - changed-files:
     - any-glob-to-any-file: 'releases/**'
 
+# Add 'group:test' label to any file changes within the 'test' folder
+group:test:
+- any:
+  - changed-files:
+    - any-glob-to-any-file: 'test/**'
+
 # Add 'group:utilities' label to any file changes within the 'utilities' folder
 group:utilities:
 - any:

--- a/test/check-semver-labels/action.yml
+++ b/test/check-semver-labels/action.yml
@@ -98,6 +98,7 @@ runs:
         ##
         echo "completing the 'debug-print-inputs' step. "
 
+    # We may want to assume the declared 'fallback' label already exists in the repo
     - name: Ensure the ${{ inputs.semver-fallback }} label exists
       id: ensure-alternate-label-exists
       shell: bash
@@ -115,6 +116,7 @@ runs:
         if [ '${{ inputs.my_action_debug }}' == 'true' ]; then echo "completing the 'ensure-alternate-label-exists' step. "; fi
       env:
         GITHUB_TOKEN: ${{ inputs.gh-token }}
+        GH_TOKEN: ${{ inputs.gh-token }}
         semver-fallback: ${{ inputs.semver-fallback }}
 
     - name: Check for semantic version labels


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request

## Proposed Changes
add second environmental GitHub token of `GH_TOKEN` to the check-semver-labels action

See the following references:
- https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28
- https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow
- https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#authenticating-in-a-github-actions-workflow-using-github-cli

