### PR TITLE
fix: comment out pr-labeler job name

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -31,7 +31,10 @@ concurrency:
 
 jobs:
   pr-labeler:
-    name: Label pull request ${{ github.event.number }}
+    #name: PR Labeler
+    # commenting out the name with the '${{ github.event.number }}' as the job could
+    # not be selected as a required status check as part of protecting branches
+    #name: Label pull request ${{ github.event.number }}
     runs-on: ubuntu-latest
     # the 'if' statement below is not needed at this time, but would be if the 'on' section above changes
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request
<!--- Please remove all comments prior to opening the pull request with this template --->

## Why are you opening this PR?

[comment out pr-labeler job name](https://github.com/rwaight/actions/commit/10420fbc2da5ba209a3f419350f547181afbc639) in order to easily add the job as a required status check


