### PR TITLE
fix(workflow): add permissions to update-tags-on-release

### DIFF
--- a/.github/workflows/actions-release-manager.yml
+++ b/.github/workflows/actions-release-manager.yml
@@ -267,6 +267,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       RELEASE_VERSION: ${{ steps.release-vars-output.outputs.RELEASE_VERSION }}
+    permissions:
+      contents: write
     if: | 
       (github.repository_owner == 'rwaight') &&
       (github.event_name=='release' && github.event.action=='published')


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request

## Why are you opening this PR?

add `contents:write` permissions to update-tags-on-release
