### PR TITLE
fix(asset): link to create-or-update-comment action

### DIFF
--- a/assets/pr-labeler/comment-checks-failure.md
+++ b/assets/pr-labeler/comment-checks-failure.md
@@ -9,6 +9,6 @@
 
 This sentence contains render template variables such as {{ .foo }} and {{ .bar }}.  This comment was created in **pull request {{ .event_number }}** using [create-or-update-comment][1].
 
-[1]: https://github.com/rwaight/actions/tree/main/github/create-or-update-comment
+[1]: https://github.com/rwaight/actions/tree/main/chatops/create-or-update-comment
 
 </details>

--- a/assets/pr-labeler/comment-checks-success.md
+++ b/assets/pr-labeler/comment-checks-success.md
@@ -6,4 +6,4 @@
 
 This sentence contains render template variables such as {{ .foo }} and {{ .bar }}. This comment was created using [create-or-update-comment][1].
 
-[1]: https://github.com/rwaight/actions/tree/main/github/create-or-update-comment
+[1]: https://github.com/rwaight/actions/tree/main/chatops/create-or-update-comment


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request

## Why are you opening this PR?

Fix the link to the templates used by the `create-or-update-comment` action

