### PR TITLE
refactor: tags for verified actions, comment commit hash

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -27,12 +27,19 @@ jobs:
           exit 1
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
 
-      - uses: actions/checkout@v4
+      - name: Checkout files from commit tree
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         with:
           fetch-depth: 0
 
-      - name: setup node
-        uses: actions/setup-node@v4
+      - name: Setup Node.js environment
+        # Verified creator: https://github.com/marketplace/actions/setup-node-js-environment
+        # Set up your GitHub Actions workflow with a specific version of node.js
+        #uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8
+        uses: actions/setup-node@v4.0.1
 
       # https://commitlint.js.org/guides/getting-started.html
       - name: Install commitlint

--- a/.github/workflows/actions-release-manager.yml
+++ b/.github/workflows/actions-release-manager.yml
@@ -177,7 +177,8 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into the default branch (i.e., "main")
       - name: Run rwaight/actions/releases/release-drafter
         #uses: rwaight/actions/releases/release-drafter@050473414fe65f13fc4adbaf3c900410c50b9f8a
-        uses: rwaight/actions/releases/release-drafter@v0.1.26
+        #uses: rwaight/actions/releases/release-drafter@v0.1.26
+        uses: rwaight/actions/releases/release-drafter@main
         id: draft-release
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         with:
@@ -428,7 +429,8 @@ jobs:
         #old-name: Update major and minor release tags for ${{ steps.release-vars-output.outputs.RELEASE_VERSION }}
         id: release-tag-updater
         #uses: rwaight/actions/releases/release-tag-updater@050473414fe65f13fc4adbaf3c900410c50b9f8a
-        uses: rwaight/actions/releases/release-tag-updater@v0.1.26
+        #uses: rwaight/actions/releases/release-tag-updater@v0.1.26
+        uses: rwaight/actions/releases/release-tag-updater@main
         with:
           #tag: ${{ steps.release-vars-output.outputs.RELEASE_VERSION }}
           tag: ${{ steps.get-release-version.outputs.full-version-ref }}

--- a/.github/workflows/actions-release-manager.yml
+++ b/.github/workflows/actions-release-manager.yml
@@ -63,7 +63,10 @@ jobs:
           exit 0
 
       - name: Checkout files from commit tree
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         with:
           fetch-depth: '0'
 
@@ -80,8 +83,10 @@ jobs:
 
       # https://github.com/actions/create-github-app-token
       - name: Creating a GitHub App Token from actions/create-github-app-token
-        #uses: actions/create-github-app-token@v1
-        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        # Verified creator: https://github.com/marketplace/actions/create-github-app-token
+        # GitHub Action for creating a GitHub App installation access token.
+        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        uses: actions/create-github-app-token@v1.10.0
         id: app-token
         with:
           # required
@@ -171,8 +176,8 @@ jobs:
 
       # Drafts your next Release notes as Pull Requests are merged into the default branch (i.e., "main")
       - name: Run rwaight/actions/releases/release-drafter
-        #uses: rwaight/actions/releases/release-drafter@v1
-        uses: rwaight/actions/releases/release-drafter@main
+        #uses: rwaight/actions/releases/release-drafter@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        uses: rwaight/actions/releases/release-drafter@v0.1.26
         id: draft-release
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         with:
@@ -276,7 +281,10 @@ jobs:
       MY_WORKFLOW_DEBUG: ${{ inputs.debug_output || 'false' }}
     steps:
       - name: Check-out the repository under GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
 
       - name: Get release version
         id: get-release-version
@@ -419,8 +427,8 @@ jobs:
       - name: Update major and minor release tags for ${{ steps.get-release-version.outputs.full-version-ref }}
         #old-name: Update major and minor release tags for ${{ steps.release-vars-output.outputs.RELEASE_VERSION }}
         id: release-tag-updater
-        #uses: rwaight/actions/releases/release-tag-updater@v1 # can use version specific or main
-        uses: rwaight/actions/releases/release-tag-updater@main # can use version specific or main
+        #uses: rwaight/actions/releases/release-tag-updater@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        uses: rwaight/actions/releases/release-tag-updater@v0.1.26
         with:
           #tag: ${{ steps.release-vars-output.outputs.RELEASE_VERSION }}
           tag: ${{ steps.get-release-version.outputs.full-version-ref }}

--- a/.github/workflows/archive/actions-label-manager.yml
+++ b/.github/workflows/archive/actions-label-manager.yml
@@ -48,11 +48,15 @@ jobs:
           exit 0
 
       - name: Checkout files from commit tree
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         
       - name: Export label config using rwaight/actions/github/export-label-config
-        #uses: rwaight/actions/github/export-label-config@v1   # can use version specific or main
-        uses: rwaight/actions/github/export-label-config@main  # can use version specific or main
+        #uses: rwaight/actions/github/export-label-config@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/github/export-label-config@v0.1.26
+        uses: rwaight/actions/github/export-label-config@main
         with:
           # This is needed if you're dealing with private repos.
           #token: ${{ secrets.MY_ACTIONS_TOKEN }}
@@ -101,11 +105,15 @@ jobs:
           exit 0
 
       - name: Checkout files from commit tree
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
 
       - name: Sync labels using rwaight/actions/github/label-sync
-        #uses: rwaight/actions/github/label-sync@v1 # can use version specific or main
-        uses: rwaight/actions/github/label-sync@main # can use version specific or main
+        #uses: rwaight/actions/github/label-sync@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/github/label-sync@v0.1.26
+        uses: rwaight/actions/github/label-sync@main
         with:
           config-file: |
             https://raw.githubusercontent.com/rwaight/actions/main/assets/my-labels-core.yml

--- a/.github/workflows/archive/actions-triage-manager.yml
+++ b/.github/workflows/archive/actions-triage-manager.yml
@@ -46,10 +46,16 @@ jobs:
           exit 0
 
       - name: Checkout files from commit tree
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
 
       - name: Run actions/labeler
-        uses: actions/labeler@v5
+        # Verified creator: https://github.com/marketplace/actions/labeler
+        # An action for automatically labelling pull requests
+        #uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
+        uses: actions/labeler@v5.0.0
 
 
   # Run 'Triage Issues and PRs', but only: At 2:15pm UTC every Tuesday; or manual (workflow_dispatch)
@@ -74,7 +80,10 @@ jobs:
           exit 0
 
       - name: Triage issues using actions/stale
-        uses: actions/stale@v8
+        # Verified creator: https://github.com/marketplace/actions/close-stale-issues
+        # Marks issues and pull requests that have not had recent interaction
+        #uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
+        uses: actions/stale@v8.0.0
         with:
           days-before-close: -1 # do not close issues or PRs
           days-before-issue-stale: 90

--- a/.github/workflows/disabled/pr-merged.yml
+++ b/.github/workflows/disabled/pr-merged.yml
@@ -18,7 +18,10 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'actions:autorelease')
     steps:
     - name: Checkout files from commit tree
-      uses: actions/checkout@v4
+      # Verified creator: https://github.com/marketplace/actions/checkout
+      # GitHub Action for checking out a repo
+      #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+      uses: actions/checkout@v4.1.3
 
     - name: Get release version
       id: get-release-version

--- a/.github/workflows/disabled/release-published.yml
+++ b/.github/workflows/disabled/release-published.yml
@@ -16,7 +16,11 @@ jobs:
   update-ref:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout files from commit tree
+      # Verified creator: https://github.com/marketplace/actions/checkout
+      # GitHub Action for checking out a repo
+      #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+      uses: actions/checkout@v4.1.3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/infra-label-manager.yml
+++ b/.github/workflows/infra-label-manager.yml
@@ -80,8 +80,10 @@ jobs:
       # Create a GitHub App Token from actions/create-github-app-token
       # https://github.com/actions/create-github-app-token
       - name: Create an App Token for ${{ matrix.repo }}
-        #uses: actions/create-github-app-token@v1
-        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        # Verified creator: https://github.com/marketplace/actions/create-github-app-token
+        # GitHub Action for creating a GitHub App installation access token.
+        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        uses: actions/create-github-app-token@v1.10.0
         id: app-token
         with:
           # required
@@ -106,6 +108,8 @@ jobs:
           (github.event_name=='schedule' && github.event.schedule=='0 10 1 */6 *') || 
           (github.event_name=='workflow_call' && inputs.sync_labels==false) || 
           (github.event_name=='workflow_dispatch' && inputs.sync_labels==false)
+        #uses: rwaight/actions/github/repository-dispatch@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/github/repository-dispatch@v0.1.26
         uses: rwaight/actions/github/repository-dispatch@main
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -118,6 +122,8 @@ jobs:
           (github.event_name=='workflow_call' && inputs.sync_labels==true) ||
           (github.event_name=='workflow_dispatch' && inputs.sync_labels==true)
         id: call-sync-labels
+        #uses: rwaight/actions/github/repository-dispatch@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/github/repository-dispatch@v0.1.26
         uses: rwaight/actions/github/repository-dispatch@main
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -195,8 +201,10 @@ jobs:
 
   #     # https://github.com/actions/create-github-app-token
   #     - name: Creating a GitHub App Token from actions/create-github-app-token
-  #       #uses: actions/create-github-app-token@v1
-  #       uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+  #       # Verified creator: https://github.com/marketplace/actions/create-github-app-token
+  #       # GitHub Action for creating a GitHub App installation access token.
+  #       #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+  #       uses: actions/create-github-app-token@v1.10.0
   #       id: app-token
   #       with:
   #         # required
@@ -214,6 +222,8 @@ jobs:
   #     - name: Send '${{ env.EVENT }}' dispatch to ${{ matrix.repo }}
   #       #if: (github.event_name=='workflow_dispatch' && inputs.sync_labels==true)
   #       id: call-sync-labels
+  #       #uses: rwaight/actions/github/repository-dispatch@050473414fe65f13fc4adbaf3c900410c50b9f8a
+  #       #uses: rwaight/actions/github/repository-dispatch@v0.1.26
   #       uses: rwaight/actions/github/repository-dispatch@main
   #       with:
   #         token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/label-manager.yml
+++ b/.github/workflows/label-manager.yml
@@ -50,8 +50,10 @@ jobs:
         if: | 
           (github.event_name=='repository_dispatch' && github.event.action=='sync-labels') || 
           (github.event_name=='workflow_dispatch' && inputs.sync_labels==true)
-        #uses: actions/create-github-app-token@v1
-        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        # Verified creator: https://github.com/marketplace/actions/create-github-app-token
+        # GitHub Action for creating a GitHub App installation access token.
+        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        uses: actions/create-github-app-token@v1.10.0
         with:
           # required
           app-id: ${{ secrets.RW_ACTIONS_APP_ID }}
@@ -60,7 +62,10 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout files from commit tree
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         with:
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
@@ -81,8 +86,9 @@ jobs:
           (github.event_name=='repository_dispatch' && github.event.action=='export-labels') ||
           (github.event_name=='repository_dispatch' && github.event.action=='sync-labels') || 
           (github.event_name=='workflow_dispatch' && inputs.sync_labels==true)
-        #uses: rwaight/actions/github/export-label-config@v1   # can use version specific or main
-        uses: rwaight/actions/github/export-label-config@main  # can use version specific or main
+        #uses: rwaight/actions/github/export-label-config@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/github/export-label-config@v0.1.26
+        uses: rwaight/actions/github/export-label-config@main
         with:
           # This is needed if you're dealing with private repos.
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
@@ -99,8 +105,9 @@ jobs:
           (github.event_name=='repository_dispatch' && github.event.action=='sync-labels') || 
           (github.event_name=='workflow_dispatch' && inputs.sync_labels==true)
           )
-        #uses: rwaight/actions/github/label-sync@v1 # can use version specific or main
-        uses: rwaight/actions/github/label-sync@main # can use version specific or main
+        #uses: rwaight/actions/github/label-sync@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/github/label-sync@v0.1.26
+        uses: rwaight/actions/github/label-sync@main
         with:
           config-file: |
             https://raw.githubusercontent.com/rwaight/actions/main/assets/my-labels-core.yml

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -62,7 +62,10 @@ jobs:
         if: (github.repository_owner != 'rwaight')
         # Save this in case we want to exit the workflow if it is called by 'rw-actions-bot[bot]'
         #if: (github.repository_owner != 'rwaight') || ${{ github.actor == 'rw-actions-bot[bot]' }}
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
 
       - name: Forked repo | Exit workflow early in forked repo
         id: check-repo-owner
@@ -175,11 +178,11 @@ jobs:
           echo "At the time this step has started, no '${{ env.GHA_LABEL_SCOPE }}' labels have been added to the PR"
           echo "The 'check-for-scope-labels' step has completed. "
 
-      # Create a GitHub App Token from actions/create-github-app-token
-      # https://github.com/actions/create-github-app-token
       - name: Create an App Token
-        #uses: actions/create-github-app-token@v1
-        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        # Verified creator: https://github.com/marketplace/actions/create-github-app-token
+        # GitHub Action for creating a GitHub App installation access token.
+        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        uses: actions/create-github-app-token@v1.10.0
         id: app-token
         # Skip running on forks or Dependabot since neither has access to secrets
         if: |
@@ -194,7 +197,10 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout files from commit tree
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         id: checkout
         # Skip running on forks or Dependabot since neither has access to secrets
         if: steps.app-token.outcome != 'skipped'
@@ -213,7 +219,10 @@ jobs:
           git config user.email ${{ secrets.RW_ACTIONS_BOT_UID }}+rw-actions-bot[bot]@users.noreply.github.com
 
       - name: Checkout files from commit tree for dependabot
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         id: checkout-dependabot
         # Run for Dependabot with the default token
         if: |
@@ -234,12 +243,17 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Apply non-versioning labels
+        # Verified creator: https://github.com/marketplace/actions/labeler
+        # An action for automatically labelling pull requests
+        #uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
+        uses: actions/labeler@v5.0.0
         id: label-pull-request
-        uses: actions/labeler@v5
         with:
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
       - name: Autorelease | Check for semantic version labels
+        #uses: rwaight/actions/test/check-semver-labels@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/test/check-semver-labels@v0.1.26
         uses: rwaight/actions/test/check-semver-labels@main
         id: check-semver-labels
         #if: contains(github.event.pull_request.labels.*.name, 'actions:autorelease')
@@ -253,8 +267,9 @@ jobs:
           my_action_debug: true
 
       - name: Check for type labels
-        uses: rwaight/actions/github/label-checker@main # can use version specific or main
-        #uses: rwaight/actions/github/label-checker@v1 # can use version specific or main
+        #uses: rwaight/actions/github/label-checker@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/github/label-checker@v0.1.26
+        uses: rwaight/actions/github/label-checker@main
         id: check-type-labels
         if: ${{ ! contains('refs/heads/autorelease', github.ref) }}
         with:
@@ -328,6 +343,8 @@ jobs:
 
       # look for a comment 
       - name: Find Comment
+        #uses: rwaight/actions/chatops/find-comment@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/chatops/find-comment@v0.1.26
         uses: rwaight/actions/chatops/find-comment@main
         id: find-comment
         if: steps.write-results.outcome != 'skipped'
@@ -341,6 +358,8 @@ jobs:
       - name: Generate comment template
         # need to use the 'label_check' outputs ('success' or 'failure' maybe?) to determine which file to use
         id: comment-template
+        #uses: rwaight/actions/utilities/render-template@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/utilities/render-template@v0.1.26
         uses: rwaight/actions/utilities/render-template@main
         if: steps.write-results.outcome != 'skipped'
         with:
@@ -358,6 +377,8 @@ jobs:
 
       - name: Create or update comment
         id: comment-on-pr
+        #uses: rwaight/actions/chatops/create-or-update-comment@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/chatops/create-or-update-comment@v0.1.26
         uses: rwaight/actions/chatops/create-or-update-comment@main
         if: steps.comment-template.outcome != 'skipped'
         with:

--- a/.github/workflows/test-build-and-push-containers.yml
+++ b/.github/workflows/test-build-and-push-containers.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout repository
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@v4
+        #uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
         uses: actions/checkout@v4.1.4
         with:
           fetch-depth: 0
@@ -84,18 +84,21 @@ jobs:
       - name: Install QEMU static binaries
         # Verified creator: https://github.com/marketplace/actions/docker-setup-qemu
         # GitHub Action to install QEMU static binaries
-        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
+        #uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
+        uses: docker/setup-qemu-action@v3.0.0
 
       - name: Setup Docker Buildx
         # Verified creator: https://github.com/marketplace/actions/docker-setup-buildx
         # GitHub Action to set up Docker Buildx
-        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb
+        #uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb
+        uses: docker/setup-buildx-action@v3.3.0
 
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the ${{ env.REGISTRY }} container registry
         # Verified creator: https://github.com/marketplace/actions/docker-login
         # GitHub Action to login against a Docker registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        #uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
+        uses: docker/login-action@v3.0.0
         with:
           #registry: ghcr.io
           registry: ${{ env.REGISTRY }}
@@ -108,7 +111,8 @@ jobs:
         id: meta
         # Verified creator: https://github.com/marketplace/actions/docker-metadata-action
         # GitHub Action to extract metadata (tags, labels) from Git reference and GitHub events for Docker 
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        #uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c
+        uses: docker/metadata-action@v5.5.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -122,7 +126,8 @@ jobs:
         id: push
         # Verified creator: https://github.com/marketplace/actions/build-and-push-docker-images
         # GitHub Action to build and push Docker images with Buildx
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        #uses: docker/build-push-action@af5a7ed5ba88268d5278f7203fb52cd833f66d6e
+        uses: docker/build-push-action@v5.2.0
         # Skip running on forks or Dependabot since neither has access to secrets
         if: |
           (github.repository == 'rwaight/actions') &&
@@ -141,6 +146,7 @@ jobs:
       - name: Generate artifact attestation
         # Verified creator: https://github.com/marketplace/actions/attest-build-provenance
         # Action for generating build provenance attestations for workflow artifacts
+        #uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940
         uses: actions/attest-build-provenance@v1.0.0
         # Skip running on forks or Dependabot since neither has access to secrets
         if: |

--- a/.github/workflows/test-infra-copycat.yml
+++ b/.github/workflows/test-infra-copycat.yml
@@ -48,11 +48,11 @@ jobs:
           - action: rwaight.github.io
             base: master
     steps:
-      # Create a GitHub App Token from actions/create-github-app-token
-      # https://github.com/actions/create-github-app-token
       - name: Create an App Token
-        #uses: actions/create-github-app-token@v1.9.0
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        # Verified creator: https://github.com/marketplace/actions/create-github-app-token
+        # GitHub Action for creating a GitHub App installation access token.
+        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        uses: actions/create-github-app-token@v1.10.0
         id: app-token
         with:
           # required
@@ -64,7 +64,10 @@ jobs:
 
       - name: Checkout files from the 'actions' repo
         id: checkout-actions-repo
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         with:
           token: ${{ steps.app-token.outputs.token }}
           #path: rw-actions
@@ -86,8 +89,9 @@ jobs:
 ## THEN use the create-pull-request action to add and commit the copied files...
 
       - name: Run the copycat action
-        #uses: rwaight/actions/utilities/copycat@main # can set to main or specific version
-        uses: rwaight/actions/utilities/copycat@v0.1.26 # can set to main or specific version
+        #uses: rwaight/actions/utilities/copycat@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/utilities/copycat@v0.1.26
+        uses: rwaight/actions/utilities/copycat@main
         id: copycat
         # see https://github.com/rwaight/actions/blob/main/utilities/copycat/copycat_README.md#usage for more detail
         with:
@@ -129,7 +133,10 @@ jobs:
 
       - name: Checkout the 'copycat-assets' branch from the '${{ matrix.repo }}' repo
         id: checkout-matrix-repo
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: ${{ github.repository_owner }}/${{ matrix.repo }}
@@ -167,8 +174,9 @@ jobs:
       # https://github.com/peter-evans/create-pull-request/blob/main/README.md
       - name: Create pull request in ${{ matrix.repo }}
         id: create-copycat-pr
-        #uses: rwaight/actions/github/create-pull-request@main # can set to main or specific version
-        uses: rwaight/actions/github/create-pull-request@v0.1.26 # can set to main or specific version
+        #uses: rwaight/actions/github/create-pull-request@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/github/create-pull-request@v0.1.26
+        uses: rwaight/actions/github/create-pull-request@main
         with:
           path: ${{ matrix.repo }}/
           #add-paths: |

--- a/.github/workflows/test-infra-updater.yml
+++ b/.github/workflows/test-infra-updater.yml
@@ -57,7 +57,10 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout files from commit tree
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         # with:
         #   fetch-depth: 0
 
@@ -84,6 +87,8 @@ jobs:
 
 
       - name: Filter changes
+        #uses: rwaight/actions/github/paths-filter@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/github/paths-filter@v0.1.26
         uses: rwaight/actions/github/paths-filter@main
         id: filter
         with:
@@ -219,11 +224,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      # Create a GitHub App Token from actions/create-github-app-token
-      # https://github.com/actions/create-github-app-token
       - name: Create an App Token
-        #uses: actions/create-github-app-token@v1
-        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c
+        # Verified creator: https://github.com/marketplace/actions/create-github-app-token
+        # GitHub Action for creating a GitHub App installation access token.
+        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        uses: actions/create-github-app-token@v1.10.0
         id: app-token
         with:
           # required
@@ -233,12 +238,17 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout files from commit tree
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Generate pull request template
         id: pull-request-template
+        #uses: rwaight/actions/utilities/render-template@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/utilities/render-template@v0.1.26
         uses: rwaight/actions/utilities/render-template@main
         #if: steps.write-results.outcome != 'skipped'
         with:
@@ -261,6 +271,8 @@ jobs:
 
   call-dispatch-label-manager:
     name: Run Infra Labeler
+    #uses: rwaight/actions/.github/workflows/infra-label-manager.yml@050473414fe65f13fc4adbaf3c900410c50b9f8a
+    #uses: rwaight/actions/.github/workflows/infra-label-manager.yml@v0.1.26
     uses: rwaight/actions/.github/workflows/infra-label-manager.yml@main
     if: ${{ needs.paths-filter.outputs.label_assets == 'true' }}
     needs: [paths-filter]

--- a/.github/workflows/test-prepare-release.yml
+++ b/.github/workflows/test-prepare-release.yml
@@ -44,10 +44,11 @@ jobs:
           echo "This workflow will now exit. "
           exit 0
 
-      # https://github.com/actions/create-github-app-token
       - name: Creating a GitHub App Token from actions/create-github-app-token
-        #uses: actions/create-github-app-token@v1
-        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        # Verified creator: https://github.com/marketplace/actions/create-github-app-token
+        # GitHub Action for creating a GitHub App installation access token.
+        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
+        uses: actions/create-github-app-token@v1.10.0
         id: app-token
         with:
           # required
@@ -55,7 +56,10 @@ jobs:
           private-key: ${{ secrets.RW_ACTIONS_APP_KEY }}
 
       - name: Checkout files from commit tree
-        uses: actions/checkout@v4
+        # Verified creator: https://github.com/marketplace/actions/checkout
+        # GitHub Action for checking out a repo
+        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@v4.1.3
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
@@ -86,9 +90,8 @@ jobs:
       - name: Get latest release info
         id: query-latest-release
         continue-on-error: true
-        #uses: ./
-        #uses: release-flow/keep-a-changelog-action@v3
-        #uses: release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32
+        #uses: rwaight/actions/git/keep-a-changelog-action@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/git/keep-a-changelog-action@v0.1.26
         uses: rwaight/actions/git/keep-a-changelog-action@main
         with:
           # https://github.com/release-flow/keep-a-changelog-action/blob/main/docs/query.md
@@ -109,9 +112,8 @@ jobs:
       - name: Get unreleased changes release info
         id: query-unreleased-changes
         continue-on-error: true
-        #uses: ./
-        #uses: release-flow/keep-a-changelog-action@v3
-        #uses: release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32
+        #uses: rwaight/actions/git/keep-a-changelog-action@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/git/keep-a-changelog-action@v0.1.26
         uses: rwaight/actions/git/keep-a-changelog-action@main
         with:
           # https://github.com/release-flow/keep-a-changelog-action/blob/main/docs/query.md
@@ -132,9 +134,8 @@ jobs:
       - name: Get latest-or-unreleased changes release info
         id: query-latest-or-unreleased-changes
         continue-on-error: true
-        #uses: ./
-        #uses: release-flow/keep-a-changelog-action@v3
-        #uses: release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32
+        #uses: rwaight/actions/git/keep-a-changelog-action@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/git/keep-a-changelog-action@v0.1.26
         uses: rwaight/actions/git/keep-a-changelog-action@main
         with:
           # https://github.com/release-flow/keep-a-changelog-action/blob/main/docs/query.md
@@ -159,11 +160,9 @@ jobs:
       # https://github.com/release-flow/keep-a-changelog-action
       - name: Update changelog using inputs.release-type (${{ github.event.inputs.release-type }})
         id: update-changelog
-        #uses: ./
-        #uses: release-flow/keep-a-changelog-action@v3
-        #uses: release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32
+        #uses: rwaight/actions/git/keep-a-changelog-action@050473414fe65f13fc4adbaf3c900410c50b9f8a
+        #uses: rwaight/actions/git/keep-a-changelog-action@v0.1.26
         uses: rwaight/actions/git/keep-a-changelog-action@main
-        #uses: release-flow/keep-a-changelog-action@v3.0.0
         with:
           # https://github.com/release-flow/keep-a-changelog-action/blob/main/docs/bump.md
           command: bump

--- a/.github/workflows/triage-stale.yml
+++ b/.github/workflows/triage-stale.yml
@@ -43,7 +43,10 @@ jobs:
           exit 0
 
       - name: Triage issues using actions/stale
-        uses: actions/stale@v9
+        # Verified creator: https://github.com/marketplace/actions/close-stale-issues
+        # Marks issues and pull requests that have not had recent interaction
+        #uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
+        uses: actions/stale@v9.0.0
         with:
           days-before-close: -1 # do not close issues or PRs
           days-before-issue-stale: 90


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request

## Why are you opening this PR?
- Use the version tag, instead of commit hash, for **verified creators**
- Use the `main` version for actions from this repo

