### PR TITLE
feat: switch to action hash with version comment

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -30,16 +30,16 @@ jobs:
       - name: Checkout files from commit tree
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         with:
           fetch-depth: 0
 
       - name: Setup Node.js environment
         # Verified creator: https://github.com/marketplace/actions/setup-node-js-environment
         # Set up your GitHub Actions workflow with a specific version of node.js
-        #uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8
-        uses: actions/setup-node@v4.0.1
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+        #uses: actions/setup-node@v4.0.1
 
       # https://commitlint.js.org/guides/getting-started.html
       - name: Install commitlint

--- a/.github/workflows/actions-release-manager.yml
+++ b/.github/workflows/actions-release-manager.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Checkout files from commit tree
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         with:
           fetch-depth: '0'
 
@@ -85,8 +85,8 @@ jobs:
       - name: Creating a GitHub App Token from actions/create-github-app-token
         # Verified creator: https://github.com/marketplace/actions/create-github-app-token
         # GitHub Action for creating a GitHub App installation access token.
-        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
-        uses: actions/create-github-app-token@v1.10.0
+        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1 # v1.10.0
+        #uses: actions/create-github-app-token@v1.10.0
         id: app-token
         with:
           # required
@@ -284,8 +284,8 @@ jobs:
       - name: Check-out the repository under GITHUB_WORKSPACE
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
 
       - name: Get release version
         id: get-release-version

--- a/.github/workflows/archive/actions-label-manager.yml
+++ b/.github/workflows/archive/actions-label-manager.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Checkout files from commit tree
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         
       - name: Export label config using rwaight/actions/github/export-label-config
         #uses: rwaight/actions/github/export-label-config@050473414fe65f13fc4adbaf3c900410c50b9f8a
@@ -107,8 +107,8 @@ jobs:
       - name: Checkout files from commit tree
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
 
       - name: Sync labels using rwaight/actions/github/label-sync
         #uses: rwaight/actions/github/label-sync@050473414fe65f13fc4adbaf3c900410c50b9f8a

--- a/.github/workflows/archive/actions-triage-manager.yml
+++ b/.github/workflows/archive/actions-triage-manager.yml
@@ -48,14 +48,14 @@ jobs:
       - name: Checkout files from commit tree
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
 
       - name: Run actions/labeler
         # Verified creator: https://github.com/marketplace/actions/labeler
         # An action for automatically labelling pull requests
-        #uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
-        uses: actions/labeler@v5.0.0
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        #uses: actions/labeler@v5.0.0
 
 
   # Run 'Triage Issues and PRs', but only: At 2:15pm UTC every Tuesday; or manual (workflow_dispatch)
@@ -82,8 +82,8 @@ jobs:
       - name: Triage issues using actions/stale
         # Verified creator: https://github.com/marketplace/actions/close-stale-issues
         # Marks issues and pull requests that have not had recent interaction
-        #uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84
-        uses: actions/stale@v8.0.0
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
+        #uses: actions/stale@v8.0.0
         with:
           days-before-close: -1 # do not close issues or PRs
           days-before-issue-stale: 90

--- a/.github/workflows/disabled/pr-merged.yml
+++ b/.github/workflows/disabled/pr-merged.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Checkout files from commit tree
       # Verified creator: https://github.com/marketplace/actions/checkout
       # GitHub Action for checking out a repo
-      #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-      uses: actions/checkout@v4.1.3
+      uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      #uses: actions/checkout@v4.1.3
 
     - name: Get release version
       id: get-release-version

--- a/.github/workflows/disabled/release-published.yml
+++ b/.github/workflows/disabled/release-published.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Checkout files from commit tree
       # Verified creator: https://github.com/marketplace/actions/checkout
       # GitHub Action for checking out a repo
-      #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-      uses: actions/checkout@v4.1.3
+      uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      #uses: actions/checkout@v4.1.3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/infra-label-manager.yml
+++ b/.github/workflows/infra-label-manager.yml
@@ -82,8 +82,8 @@ jobs:
       - name: Create an App Token for ${{ matrix.repo }}
         # Verified creator: https://github.com/marketplace/actions/create-github-app-token
         # GitHub Action for creating a GitHub App installation access token.
-        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
-        uses: actions/create-github-app-token@v1.10.0
+        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1 # v1.10.0
+        #uses: actions/create-github-app-token@v1.10.0
         id: app-token
         with:
           # required

--- a/.github/workflows/label-manager.yml
+++ b/.github/workflows/label-manager.yml
@@ -52,8 +52,8 @@ jobs:
           (github.event_name=='workflow_dispatch' && inputs.sync_labels==true)
         # Verified creator: https://github.com/marketplace/actions/create-github-app-token
         # GitHub Action for creating a GitHub App installation access token.
-        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
-        uses: actions/create-github-app-token@v1.10.0
+        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1 # v1.10.0
+        #uses: actions/create-github-app-token@v1.10.0
         with:
           # required
           app-id: ${{ secrets.RW_ACTIONS_APP_ID }}
@@ -64,8 +64,8 @@ jobs:
       - name: Checkout files from commit tree
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         with:
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -64,8 +64,8 @@ jobs:
         #if: (github.repository_owner != 'rwaight') || ${{ github.actor == 'rw-actions-bot[bot]' }}
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
 
       - name: Forked repo | Exit workflow early in forked repo
         id: check-repo-owner
@@ -181,8 +181,8 @@ jobs:
       - name: Create an App Token
         # Verified creator: https://github.com/marketplace/actions/create-github-app-token
         # GitHub Action for creating a GitHub App installation access token.
-        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
-        uses: actions/create-github-app-token@v1.10.0
+        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1 # v1.10.0
+        #uses: actions/create-github-app-token@v1.10.0
         id: app-token
         # Skip running on forks or Dependabot since neither has access to secrets
         if: |
@@ -199,8 +199,8 @@ jobs:
       - name: Checkout files from commit tree
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         id: checkout
         # Skip running on forks or Dependabot since neither has access to secrets
         if: steps.app-token.outcome != 'skipped'
@@ -221,8 +221,8 @@ jobs:
       - name: Checkout files from commit tree for dependabot
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         id: checkout-dependabot
         # Run for Dependabot with the default token
         if: |
@@ -245,8 +245,8 @@ jobs:
       - name: Apply non-versioning labels
         # Verified creator: https://github.com/marketplace/actions/labeler
         # An action for automatically labelling pull requests
-        #uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
-        uses: actions/labeler@v5.0.0
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        #uses: actions/labeler@v5.0.0
         id: label-pull-request
         with:
           repo-token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-build-and-push-containers.yml
+++ b/.github/workflows/test-build-and-push-containers.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Checkout repository
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        #uses: actions/checkout@v4.1.4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -76,8 +76,8 @@ jobs:
         if: ${{ matrix.go-version }}
         # Verified creator: https://github.com/marketplace/actions/setup-go-environment
         # Set up your GitHub Actions workflow with a specific version of Go
-        #uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        #uses: actions/setup-go@v4.1.0
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -90,15 +90,15 @@ jobs:
       - name: Setup Docker Buildx
         # Verified creator: https://github.com/marketplace/actions/docker-setup-buildx
         # GitHub Action to set up Docker Buildx
-        #uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb
-        uses: docker/setup-buildx-action@v3.3.0
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+        #uses: docker/setup-buildx-action@v3.3.0
 
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the ${{ env.REGISTRY }} container registry
         # Verified creator: https://github.com/marketplace/actions/docker-login
         # GitHub Action to login against a Docker registry
-        #uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        #uses: docker/login-action@v3.0.0
         with:
           #registry: ghcr.io
           registry: ${{ env.REGISTRY }}
@@ -111,8 +111,8 @@ jobs:
         id: meta
         # Verified creator: https://github.com/marketplace/actions/docker-metadata-action
         # GitHub Action to extract metadata (tags, labels) from Git reference and GitHub events for Docker 
-        #uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c
-        uses: docker/metadata-action@v5.5.0
+        uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5.5.0
+        #uses: docker/metadata-action@v5.5.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -126,8 +126,8 @@ jobs:
         id: push
         # Verified creator: https://github.com/marketplace/actions/build-and-push-docker-images
         # GitHub Action to build and push Docker images with Buildx
-        #uses: docker/build-push-action@af5a7ed5ba88268d5278f7203fb52cd833f66d6e
-        uses: docker/build-push-action@v5.2.0
+        uses: docker/build-push-action@af5a7ed5ba88268d5278f7203fb52cd833f66d6e # v5.2.0
+        #uses: docker/build-push-action@v5.2.0
         # Skip running on forks or Dependabot since neither has access to secrets
         if: |
           (github.repository == 'rwaight/actions') &&
@@ -146,8 +146,8 @@ jobs:
       - name: Generate artifact attestation
         # Verified creator: https://github.com/marketplace/actions/attest-build-provenance
         # Action for generating build provenance attestations for workflow artifacts
-        #uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940
-        uses: actions/attest-build-provenance@v1.0.0
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+        #uses: actions/attest-build-provenance@v1.0.0
         # Skip running on forks or Dependabot since neither has access to secrets
         if: |
           (github.repository == 'rwaight/actions') &&

--- a/.github/workflows/test-infra-copycat.yml
+++ b/.github/workflows/test-infra-copycat.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Create an App Token
         # Verified creator: https://github.com/marketplace/actions/create-github-app-token
         # GitHub Action for creating a GitHub App installation access token.
-        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
-        uses: actions/create-github-app-token@v1.10.0
+        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1 # v1.10.0
+        #uses: actions/create-github-app-token@v1.10.0
         id: app-token
         with:
           # required
@@ -66,8 +66,8 @@ jobs:
         id: checkout-actions-repo
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         with:
           token: ${{ steps.app-token.outputs.token }}
           #path: rw-actions
@@ -135,8 +135,8 @@ jobs:
         id: checkout-matrix-repo
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: ${{ github.repository_owner }}/${{ matrix.repo }}

--- a/.github/workflows/test-infra-updater.yml
+++ b/.github/workflows/test-infra-updater.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Checkout files from commit tree
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         # with:
         #   fetch-depth: 0
 
@@ -227,8 +227,8 @@ jobs:
       - name: Create an App Token
         # Verified creator: https://github.com/marketplace/actions/create-github-app-token
         # GitHub Action for creating a GitHub App installation access token.
-        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
-        uses: actions/create-github-app-token@v1.10.0
+        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1 # v1.10.0
+        #uses: actions/create-github-app-token@v1.10.0
         id: app-token
         with:
           # required
@@ -240,8 +240,8 @@ jobs:
       - name: Checkout files from commit tree
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/test-prepare-release.yml
+++ b/.github/workflows/test-prepare-release.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Creating a GitHub App Token from actions/create-github-app-token
         # Verified creator: https://github.com/marketplace/actions/create-github-app-token
         # GitHub Action for creating a GitHub App installation access token.
-        #uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1
-        uses: actions/create-github-app-token@v1.10.0
+        uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1 # v1.10.0
+        #uses: actions/create-github-app-token@v1.10.0
         id: app-token
         with:
           # required
@@ -58,8 +58,8 @@ jobs:
       - name: Checkout files from commit tree
         # Verified creator: https://github.com/marketplace/actions/checkout
         # GitHub Action for checking out a repo
-        #uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        #uses: actions/checkout@v4.1.3
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/triage-stale.yml
+++ b/.github/workflows/triage-stale.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Triage issues using actions/stale
         # Verified creator: https://github.com/marketplace/actions/close-stale-issues
         # Marks issues and pull requests that have not had recent interaction
-        #uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
-        uses: actions/stale@v9.0.0
+        uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        #uses: actions/stale@v9.0.0
         with:
           days-before-close: -1 # do not close issues or PRs
           days-before-issue-stale: 90


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request

## Why are you opening this PR?
Use commit hashes for actions
- The feature was added to dependabot in https://github.com/dependabot/dependabot-core/pull/5951
- https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/

