### PR TITLE
build: output image-skip note and reason in set-skip-create action

### DIFF
--- a/builders/set-skip-create/action.yml
+++ b/builders/set-skip-create/action.yml
@@ -75,6 +75,12 @@ outputs:
   image-skip-create:
     description: "The determine variable to be provided as the Packer `skip_create*` variable. "
     value: ${{ steps.set-skip-create-output.outputs.IMAGE_SKIP_CREATE }}
+  image-skip-note:
+    description: "The short note of what Packer will be instructed to do when using the `skip_create*` variable. "
+    value: ${{ steps.set-skip-create-output.outputs.IMAGE_SKIP_NOTE }}
+  image-skip-reason:
+    description: "The reason for determining the 'image-skip-create' output. "
+    value: ${{ steps.set-skip-create-output.outputs.IMAGE_SKIP_REASON }}
 
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-composite-actions
 runs:


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request


## Why are you opening this PR?

update the `builders/set-skip-create` action; specifically output image-skip note and reason

## Related issues
<!--- Are there any related issues? --->
<!--- Please include the URL to the related issue(s). If the PR fixes a bug or resolves a feature request, be sure to link to that issue. --->
**Issue URL(s)**: 
