### PR TITLE
refactor: move shell option to end of each step config

### DIFF
--- a/instruqt/track-delete/action.yml
+++ b/instruqt/track-delete/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
   - name: Run track delete
-    shell: bash
     run: |
       cd ${{ inputs.path }}
       docker run -e INSTRUQT_TOKEN=${{ env.INSTRUQT_TOKEN }} --workdir="/track" --mount type=bind,source="$(pwd)",target=/track instruqt/cli track delete
+    shell: bash

--- a/instruqt/track-dev/action.yml
+++ b/instruqt/track-dev/action.yml
@@ -8,7 +8,6 @@ runs:
   using: composite
   steps:
   - name: Create dev track
-    shell: bash
     run: |
       cd ${{ inputs.path }}
 
@@ -36,3 +35,4 @@ runs:
       
       # Set into maintenance mode
       yq eval --inplace '.maintenance = true' track.yml
+    shell: bash

--- a/instruqt/track-promote/action.yml
+++ b/instruqt/track-promote/action.yml
@@ -11,7 +11,6 @@ runs:
   using: composite
   steps:
   - name: Inject track id and prepare for push
-    shell: bash
     run: |
 
       cd ${{ inputs.path }}
@@ -26,3 +25,4 @@ runs:
 
       # Remove maintenance tag
       sed -i 's/^maintenance: true/maintenance: false/g' track.yml
+    shell: bash

--- a/instruqt/track-pull/action.yml
+++ b/instruqt/track-pull/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
   - name: Run track pull
-    shell: bash
     run: |
       cd ${{ inputs.path }}
       docker run -e INSTRUQT_TOKEN=${{ env.INSTRUQT_TOKEN }} --workdir="/track" --mount type=bind,source="$(pwd)",target=/track instruqt/cli track pull --force
+    shell: bash

--- a/instruqt/track-push/action.yml
+++ b/instruqt/track-push/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
   - name: Run track push
-    shell: bash
     run: |
       cd ${{ inputs.path }}
       docker run -e INSTRUQT_TOKEN=${{ env.INSTRUQT_TOKEN }} --workdir="/track" --mount type=bind,source="$(pwd)",target=/track instruqt/cli track push --force
+    shell: bash

--- a/instruqt/track-tags/action.yml
+++ b/instruqt/track-tags/action.yml
@@ -11,7 +11,6 @@ runs:
   using: composite
   steps:
   - name: Run CURL request 
-    shell: bash
     run: |
       
       cat >query.json <<EOF
@@ -32,3 +31,4 @@ runs:
       else 
         echo "CI is enabled for this track"
       fi
+    shell: bash

--- a/instruqt/track-test/action.yml
+++ b/instruqt/track-test/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
   - name: Run track test
-    shell: bash
     run: |
       cd ${{ inputs.path }}
       docker run -e INSTRUQT_TOKEN=${{ env.INSTRUQT_TOKEN }} --workdir="/track" --mount type=bind,source="$(pwd)",target=/track instruqt/cli track test --skip-fail-check
+    shell: bash

--- a/instruqt/track-validate/action.yml
+++ b/instruqt/track-validate/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
   - name: Run track validate
-    shell: bash
     run: |
       cd ${{ inputs.path }}
       docker run -e INSTRUQT_TOKEN=${{ env.INSTRUQT_TOKEN }} --workdir="/track" --mount type=bind,source="$(pwd)",target=/track instruqt/cli track validate
+    shell: bash

--- a/test/get-next-semver/action.yml
+++ b/test/get-next-semver/action.yml
@@ -76,20 +76,19 @@ runs:
   steps:
     - name: Validate that the runner OS is Linux
       if: ${{ runner.os != 'Linux' }}
-      shell: bash
       run: |
         echo "::error file=get-next-semver,title=⛔ error::This action supports Linux only"
         exit 1
+      shell: bash
 
     - name: Greet the triggering_actor
       if: inputs.verbose=='true'
-      shell: bash
       run: echo Hello ${{ github.triggering_actor }}, the verbose variable is set to true.
+      shell: bash
 
     - name: Verbose | Print the release-type
       if: inputs.verbose=='true'
       id: verbose-print-release-type
-      shell: bash
       run: | 
         ## Print the inputs if inputs.verbose=='true'
         ## the double number signs below are for line spacing and readability only
@@ -99,6 +98,7 @@ runs:
         echo "release-type is:  ${{ inputs.release-type }} "
         ##
         echo "completing the 'verbose-print-release-type' step. "
+      shell: bash
 
     - name: Validate the release-type input
       # https://github.com/orgs/community/discussions/25252#discussioncomment-3247116
@@ -112,7 +112,6 @@ runs:
         contains('preminor', inputs.release-type) ||
         contains('prepatch', inputs.release-type) ||
         contains('pretoprod', inputs.release-type)
-      shell: bash
       run: |
         ## Validate the release-type input
         ## the double number signs below are for line spacing and readability only
@@ -122,11 +121,11 @@ runs:
             echo "::notice file=get-next-semver,title=validate-input-release-type::The 'release-type' is valid."
         fi
         ##
+      shell: bash
 
     - name: Error if the release-type input is incorrect
       id: error-incorrect-release-type
       if: ${{ !contains(fromJSON('["major", "minor", "patch", "prerelease", "premajor", "preminor", "prepatch", "pretoprod"]'), inputs.release-type) }}
-      shell: bash
       run: |
         ## Error if the release-type input is incorrect
         ## the double number signs below are for line spacing and readability only
@@ -136,6 +135,7 @@ runs:
         echo "::error file=get-next-semver,title=⛔ error-incorrect-release-type,hint::Invalid 'release-type', must be one of: major, minor, patch, prerelease, premajor, preminor, prepatch, or pretoprod"
         echo "completing the 'error-incorrect-release-type' step. "
         exit 1
+      shell: bash
 
     # - name: Validate the release-type input
     #   # https://github.com/orgs/community/discussions/25252#discussioncomment-3247116
@@ -147,15 +147,14 @@ runs:
     #   #   ${{ !contains(inputs.release-type, 'minor') }} || 
     #   #   ${{ !contains(inputs.release-type, 'patch') }} || 
     #   #   ${{ !contains(inputs.release-type, 'pre') }}
-    #   shell: bash
     #   run: |
     #     echo "::error file=get-next-semver,title=⛔ validate-input-release-type-2::Invalid 'release-type', must be one of: major, minor, patch, premajor, preminor, prepatch, or prerelease"
     #     #exit 1
+    #   shell: bash
 
     - name: Verbose | Print the inputs
       if: inputs.verbose=='true'
       id: verbose-print-inputs
-      shell: bash
       run: | 
         ## Print the inputs if inputs.verbose=='true'
         ## the double number signs below are for line spacing and readability only
@@ -170,11 +169,11 @@ runs:
         echo "verbose is             :  ${{ inputs.verbose }} "
         ##
         echo "completing the 'verbose-print-inputs' step. "
+      shell: bash
 
     - name: Notice | The pre-release-id value is blank
       if: inputs.pre-release-id==''
       id: blank-pre-release-id
-      shell: bash
       run: | 
         ## Ensure the pre-release-id is not blank
         ## the double number signs below are for line spacing and readability only
@@ -183,10 +182,10 @@ runs:
         echo ""
         echo "::notice file=get-next-semver,title=blank-pre-release-id::The pre-release-id value is blank, it is not using the default value."
         echo "completing the 'blank-pre-release-id' step. "
+      shell: bash
 
     - name: Add inputs to the environment
       id: add-inputs-to-env
-      shell: bash
       run: | 
         ## the double number signs below are for line spacing and readability only
         ##
@@ -215,10 +214,10 @@ runs:
         echo "VERBOSE=${{ inputs.verbose }}" >> $GITHUB_ENV
         ##
         echo "The 'add-inputs-to-env' step has finished."
+      shell: bash
 
     - name: Determine if pre-releases are included
       id: determine-prereleases
-      shell: bash
       run: | 
         ## the double number signs below are for line spacing and readability only
         ##
@@ -243,10 +242,10 @@ runs:
         echo "prerelease_eval=${prerelease_eval}" >> $GITHUB_OUTPUT
         ##
         echo "The 'determine-prereleases' step has finished."
+      shell: bash
 
     - name: Get the current release version
       id: get-current-release
-      shell: bash
       run: |
         ## Get the current release version
         ## the double number signs below are for line spacing and readability only
@@ -377,10 +376,10 @@ runs:
         if [ '${{ inputs.verbose }}' == 'true' ]; then echo "completing the 'get-current-release' step. "; fi
       env:
         GH_TOKEN: ${{ inputs.gh-token }}
+      shell: bash
 
     - name: Get the current tag
       id: get-current-tag
-      shell: bash
       run: |
         ## Get the current tag
         ## the double number signs below are for line spacing and readability only
@@ -510,10 +509,10 @@ runs:
         if [ '${{ inputs.verbose }}' == 'true' ]; then echo "completing the 'get-current-tag' step. "; fi
       env:
         GH_TOKEN: ${{ inputs.gh-token }}
+      shell: bash
 
     - name: Compare the current tag to the current release version
       id: compare-tag-to-current-release
-      shell: bash
       run: |
         ## Compare the current release version to the current tag version
         ## the double number signs below are for line spacing and readability only
@@ -548,10 +547,10 @@ runs:
       env:
         current_tag_version: ${{ steps.get-current-tag.outputs.current-tag-version }}
         current_release_version: ${{ steps.get-current-release.outputs.current-release-version }}
+      shell: bash
 
     - name: Set the next tag version
       id: set-next-tag
-      shell: bash
       run: |
         ## Set the next tag version
         ## the double number signs below are for line spacing and readability only
@@ -726,13 +725,13 @@ runs:
         ## echo "$version" | awk 'BEGIN{FS=OFS="."} {$1+=1;$2=0;$3=0} 1' | awk 'BEGIN{FS=OFS="-rc"} {$2+=1} 1'
         ## Remove the prerelease ID:
         ## echo "$version" | awk 'BEGIN{FS=OFS="-rc"} { print $1 }'
+      shell: bash
 
     - name: Set the next release version number
       # remove 'v' from the 'next_tag_version'
       # syntax is: `echo "${VERSION//v}"`
       # command: `next_ver_number=$(echo "${VERSION//v}")`
       id: set-next-version
-      shell: bash
       run: |
         ## Set the next release version
         ## the double number signs below are for line spacing and readability only
@@ -808,10 +807,10 @@ runs:
       # next_ver_number=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="v"} { print $2 }')
       env:
         next_tag_version: ${{ steps.set-next-tag.outputs.next-tag-version }}
+      shell: bash
 
     - name: Validate the next tag version
       id: validate-next-release
-      shell: bash
       run: |
         ## Validate the next tag version
         ## the double number signs below are for line spacing and readability only
@@ -841,10 +840,10 @@ runs:
       env:
         next_tag_version: ${{ steps.set-next-tag.outputs.next-tag-version }}
         is_next_prerelease: ${{ steps.set-next-tag.outputs.is-next-prerelease }}
+      shell: bash
 
     - name: Validate the next version number
       id: validate-next-version-number
-      shell: bash
       run: |
         ## Validate the next version number
         ## the double number signs below are for line spacing and readability only
@@ -876,10 +875,10 @@ runs:
       env:
         next_version_number: ${{ steps.set-next-version.outputs.next-version-number }}
         is_next_number_prerelease: ${{ steps.set-next-version.outputs.is-next-number-prerelease }}
+      shell: bash
 
     - name: Compare the current release version to the next tag version
       id: compare-current-to-next-release
-      shell: bash
       run: |
         ## Compare the current release version to the next tag version
         ## the double number signs below are for line spacing and readability only
@@ -915,10 +914,10 @@ runs:
         #current_tag_version: ${{ steps.get-current-tag.outputs.current-tag-version }}
         current_release_version: ${{ steps.get-current-release.outputs.current-release-version }}
         next_tag_version: ${{ steps.set-next-tag.outputs.next-tag-version }}
+      shell: bash
 
     - name: Compare the the next version match the next tag version
       id: compare-next-version-to-next-tag
-      shell: bash
       run: |
         ## Compare the the next version match the next tag version
         ## the double number signs below are for line spacing and readability only
@@ -957,13 +956,13 @@ runs:
         next-tag-version: ${{ steps.set-next-tag.outputs.next-tag-version }}
         is-next-number-prerelease: ${{ steps.set-next-version.outputs.is-next-number-prerelease }}
         next-version-number: ${{ steps.set-next-version.outputs.next-version-number }}
+      shell: bash
 
     # - name: Error if the current version matches the next version
     #   id: error-matched-versions
     #   if: ( ${{ steps.compare-current-to-next-release.outputs.does-current-match-next }} == 'true' )
     #   #not working properly#if: ${{ steps.compare-current-to-next-release.outputs.does-current-match-next }}
     #   #not working properly#if: ( '${{ steps.compare-current-to-next-release.outputs.does-current-match-next }}' == 'true' )
-    #   shell: bash
     #   run: |
     #     ## Error if the current version matches the next version
     #     ## the double number signs below are for line spacing and readability only
@@ -981,10 +980,10 @@ runs:
     #     current-release-version: ${{ steps.get-current-release.outputs.current-release-version }}
     #     next-tag-version: ${{ steps.set-next-tag.outputs.next-tag-version }}
     #     does-current-match-next: ${{ steps.compare-current-to-next-release.outputs.does-current-match-next }}
+    #   shell: bash
 
     - name: Validate that the next version match the next tag version
       id: validate-next-versions-are-matched
-      shell: bash
       run: |
         ## Validate that the next version match the next tag version
         ## the double number signs below are for line spacing and readability only
@@ -1017,13 +1016,13 @@ runs:
         next-version-number: ${{ steps.set-next-version.outputs.next-version-number }}
         is-next-number-prerelease: ${{ steps.set-next-version.outputs.is-next-number-prerelease }}
         does-next-version-match-next-tag: ${{ steps.compare-next-version-to-next-tag.outputs.does-next-version-match-next-tag }}
+      shell: bash
 
     - name: Validate that the current version does not match the next version
       id: validate-version-not-matched
       #if: ( ${{ steps.compare-current-to-next-release.outputs.does-current-match-next }} != 'true' )
       #not working properly#if: ${{ steps.compare-current-to-next-release.outputs.does-current-match-next }} != 'true'
       #not working properly#if: ( '${{ steps.compare-current-to-next-release.outputs.does-current-match-next }}' != 'true' )
-      shell: bash
       run: |
         ## Validate that the current version does not match the next version
         ## the double number signs below are for line spacing and readability only
@@ -1061,11 +1060,11 @@ runs:
         is-next-prerelease: ${{ steps.set-next-tag.outputs.is-next-prerelease }}
         does-current-match-next: ${{ steps.compare-current-to-next-release.outputs.does-current-match-next }}
         does-tag-match-release: ${{ steps.compare-tag-to-current-release.outputs.does-tag-match-release }}
+      shell: bash
 
     - name: Verbose | Print the outputs
       if: inputs.verbose=='true'
       id: verbose-print-outputs
-      shell: bash
       run: | 
         ## Print the outputs if inputs.verbose=='true'
         ## the double number signs below are for line spacing and readability only
@@ -1103,3 +1102,4 @@ runs:
         does-current-match-next: ${{ steps.compare-current-to-next-release.outputs.does-current-match-next }}
         does-tag-match-release: ${{ steps.compare-tag-to-current-release.outputs.does-tag-match-release }}
         does-next-version-match-next-tag: ${{ steps.compare-next-version-to-next-tag.outputs.does-next-version-match-next-tag }}
+      shell: bash

--- a/test/template-composite/action.yml
+++ b/test/template-composite/action.yml
@@ -36,20 +36,19 @@ runs:
     - name: Validate that the runner OS is Linux
       if: ${{ runner.os != 'Linux' }}
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
-      shell: bash
       run: |
         echo "::error title=⛔ error hint::This action supports Linux only"
         exit 1
+      shell: bash
 
     - name: Greet the triggering_actor
       if: inputs.verbose=='true'
-      shell: bash
       run: echo Hello ${{ github.triggering_actor }}, the verbose variable is set to true.
+      shell: bash
 
     - name: Verbose | Print the inputs
       if: inputs.verbose=='true'
       id: verbose-print-inputs
-      shell: bash
       run: | 
         ## Print the inputs if inputs.verbose=='true'
         ## the double number signs below are for line spacing and readability only
@@ -58,10 +57,10 @@ runs:
         echo "my-example-input1 is set to ${{ inputs.my-example-input1 }} "
         echo "verbose is set to ${{ inputs.verbose }} "
         ##
+      shell: bash
 
     - name: This is a template only
       id: template-example-output
-      shell: bash
       run: |
         ## Print a message about this being a template action only.
         ## the double number signs below are for line spacing and readability only
@@ -78,10 +77,11 @@ runs:
         echo "EXAMPLE_ACTION_OUTPUT1=${template_action_datetime}" >> $GITHUB_ENV
         echo "EXAMPLE_ACTION_OUTPUT1=${template_action_datetime}" >> "$GITHUB_OUTPUT"
         echo ""
+      shell: bash
 
     # Output variables for the action
     - name: Output variables from this job to the action output
       id: set-vars-output
-      shell: bash
       run: |
         echo "EXAMPLE_ACTION_OUTPUT1=${EXAMPLE_ACTION_OUTPUT1}" >> "$GITHUB_OUTPUT"
+      shell: bash

--- a/test/update-json-field/action.yml
+++ b/test/update-json-field/action.yml
@@ -68,20 +68,19 @@ runs:
   steps:
     - name: Validate that the runner OS is Linux
       if: ${{ runner.os != 'Linux' }}
-      shell: bash
       run: |
         echo "::error title=⛔ error hint::This action supports Linux only"
         exit 1
+      shell: bash
 
     - name: Greet the triggering_actor
       if: inputs.verbose=='true'
-      shell: bash
       run: echo Hello ${{ github.triggering_actor }}, the verbose variable is set to true.
+      shell: bash
 
     - name: Verbose | Print the inputs
       if: inputs.verbose=='true'
       id: verbose-print-inputs
-      shell: bash
       run: | 
         ## Print the inputs if inputs.verbose=='true'
         ## the double number signs below are for line spacing and readability only
@@ -100,10 +99,10 @@ runs:
         echo "verbose is        :  ${{ inputs.verbose }} "
         ##
         echo "completing the 'verbose-print-inputs' step. "
+      shell: bash
 
     - name: Get the current value of the ${{ inputs.vars-field }} field
       id: get-current-value
-      shell: bash
       run: |
         ## Get the current value of ${{ env.vars_field }}
         ## the double number signs below are for line spacing and readability only
@@ -133,10 +132,10 @@ runs:
         json_vars_file: ${{ inputs.json-file }}
         vars_field: ${{ inputs.vars-field }}
         vars_new_value: ${{ inputs.vars-new-value }}
+      shell: bash
 
     - name: Update the value of the json field
       id: update-json-field-value
-      shell: bash
       run: |
         ## Update the value of the json field
         ## the double number signs below are for line spacing and readability only
@@ -180,10 +179,10 @@ runs:
         json_vars_file: ${{ inputs.json-file }}
         vars_field: ${{ inputs.vars-field }}
         vars_new_value: ${{ inputs.vars-new-value }}
+      shell: bash
 
     - name: Get the updated value of the ${{ inputs.vars-field }} field
       id: get-updated-value
-      shell: bash
       run: |
         ## Get the updated value of the ${{ inputs.vars-field }} field
         ## the double number signs below are for line spacing and readability only
@@ -234,6 +233,7 @@ runs:
         json_vars_file: ${{ inputs.json-file }}
         vars_field: ${{ inputs.vars-field }}
         vars_new_value: ${{ inputs.vars-new-value }}
+      shell: bash
 
     # - name: Commit the changes to the '${{ inputs.json-file }}' file
     #   id: commit-json-value-changes
@@ -263,7 +263,6 @@ runs:
     - name: Verbose | Print the outputs
       if: inputs.verbose=='true'
       id: verbose-print-outputs
-      shell: bash
       run: | 
         ## Print the outputs if inputs.verbose=='true'
         ## the double number signs below are for line spacing and readability only
@@ -284,12 +283,13 @@ runs:
         json_vars_file: ${{ inputs.json-file }}
         vars_field: ${{ inputs.vars-field }}
         vars_new_value: ${{ inputs.vars-new-value }}
+      shell: bash
 
     # - name: Modify a JSON key value in place
     #   id: update-json-in-place
-    #   shell: bash
     #   run: |
     #     echo "special thanks to this person on stack overflow ... "
     #     echo "https://stackoverflow.com/questions/42716734/modify-a-key-value-in-a-json-using-jq-in-place "
     #     tmp=$(mktemp)
     #     jq '.my_custom_field = "ami-02d8sdfsdf"' my-custom-variables.json > "$tmp" && mv "$tmp" my-custom-variables.json
+    #   shell: bash

--- a/utilities/install-yq/action.yml
+++ b/utilities/install-yq/action.yml
@@ -6,12 +6,12 @@ runs:
   steps:
 
     - name: Download yq package
-      shell: bash
       run: wget https://github.com/mikefarah/yq/releases/download/v4.26.1/yq_linux_amd64
+      shell: bash
 
     - name: Configure yq executable
-      shell: bash
       run: sudo mv yq_linux_amd64 /usr/bin/yq && chmod +x /usr/bin/yq
+      shell: bash
 
 branding:
   # Ref: https://haya14busa.github.io/github-action-brandings/

--- a/vars/build-method/action.yml
+++ b/vars/build-method/action.yml
@@ -70,15 +70,14 @@ runs:
     - name: Validate that the runner OS is Linux
       if: ${{ runner.os != 'Linux' }}
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
-      shell: bash
       run: |
         echo "error in the action '${{ github.action }}' at file path: '${{ github.action_path }}' "
         echo "::error file=builders/set-method/action.yml,title=⛔ build-method error hint::This action supports Linux only"
         exit 1
+      shell: bash
 
     - name: Greet the triggering_actor
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
-      shell: bash
       run: | 
         echo "Hello ${{ github.triggering_actor }}, the verbose variable is set to true."
         echo ""
@@ -89,13 +88,13 @@ runs:
         echo "  action repo  :  ${{ github.action_repository }} "
         echo "  action status:  ${{ github.action_status }} "
         echo ""
+      shell: bash
 
     - name: Show GitHub runner context
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
       # to do:  run this if either the verbose input is true or the runner.debug is true
       id: show-runner-context
       ## The 'runner.*' and 'RUNNER_*' variables are not available in the WORKFLOW env context or the top-level JOB context, but are available in the STEP env context
-      shell: bash
       env:
         EVAL_GH_VAR_RUNNER_DEBUG_EQ0: ${{ runner.debug == '0' }}
         EVAL_GH_VAR_RUNNER_DEBUG_EQ1: ${{ runner.debug == '1' }}
@@ -140,11 +139,11 @@ runs:
         ##
         echo "::endgroup::"
       ## The 'runner.*' and 'RUNNER_*' variables are not available in the WORKFLOW env context or the top-level JOB context, but are available in the STEP env context
+      shell: bash
 
     - name: Verbose | Print the inputs
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
       id: verbose-print-inputs
-      shell: bash
       run: | 
         echo "::group::starting the 'verbose-print-inputs' step... "
         ## Print the inputs if inputs.verbose=='true'
@@ -167,11 +166,11 @@ runs:
         echo "finishing the 'verbose-print-inputs' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Verbose | Print GitHub Context
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
       id: verbose-github-context
-      shell: bash
       run: | 
         echo "::group::starting the 'verbose-github-context' step... "
         ## Print the inputs if inputs.verbose=='true'
@@ -201,6 +200,7 @@ runs:
         echo "finishing the 'verbose-github-context' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Checkout files from commit tree
       # Verified creator: https://github.com/marketplace/actions/checkout
@@ -225,7 +225,6 @@ runs:
     - name: Extra | The ref_type is 'tag'
       id: extra-ref-type-tag
       if: github.ref_type == 'tag'
-      shell: bash
       run: |
         echo "::group::starting the 'extra-ref-type-tag' step... "
         echo "The ref_type is 'tag' "
@@ -240,6 +239,7 @@ runs:
         echo "finishing the 'extra-ref-type-tag' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Extra | The tag starts with the proper version numbering syntax
       id: extra-tag-with-version-syntax
@@ -250,7 +250,6 @@ runs:
       #    or keep the single digit, but match one or more with `+`:
       #        'v[0-9]+.[0-9]+.[0-9]+'
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      shell: bash
       run: |
         echo "::group::starting the 'extra-tag-with-version-syntax' step... "
         echo "The ref_type is 'tag' and the tag starts with the proper version numbering syntax "
@@ -265,6 +264,7 @@ runs:
         echo "finishing the 'extra-tag-with-version-syntax' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Set environmental variables used to evaluate the build method
       id: set-eval-method-env-vars
@@ -273,7 +273,6 @@ runs:
       #   - 'EVAL_REASON' is set to 'tbd'
       #   - 'GH_DEFAULT_BRANCH' is set to '${{ github.event.repository.default_branch }}'
       if: ${{ always() }}
-      shell: bash
       run: |
         echo "::group::starting the 'set-eval-method-env-vars' step... "
         echo ""
@@ -291,13 +290,13 @@ runs:
         echo ""
         echo "finishing the 'set-eval-method-env-vars' step... "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_METHOD | Strategy input is not 'github-event'
       #name: Strategy Input | Build method is 'convert-to-main' from input
       id: set-method-from-input-strategy
       #if: (inputs.strategy=='convert-to-main')
       if: (inputs.strategy!='github-event')
-      shell: bash
       run: |
         echo "::group::starting the 'set-method-from-input-strategy' step... "
         echo ""
@@ -348,11 +347,11 @@ runs:
         echo ""
         echo "finishing the 'set-method-from-input-strategy' step... "
         echo "::endgroup::"
+      shell: bash
 
     - name: get-tag-version
       id: get-tag-version
       if: (github.ref_type == 'tag')
-      shell: bash
       run: |
         echo "::group::starting step 'get-tag-version' "
         VERSION="${{ github.event.release.tag_name || github.ref_name }}"
@@ -388,12 +387,12 @@ runs:
         echo ""
         echo "completing the 'get-tag-version' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: get-tag-version | Print outputs
       id: check-get-tag-version
       #if: (github.ref_type == 'tag')
       if: ${{ steps.get-tag-version.outputs.full-version-ref }}
-      shell: bash
       run: |
         echo "::group::starting step 'check-get-tag-version' "
         echo "## get-tag-version outputs"
@@ -412,6 +411,7 @@ runs:
         MINOR_REF: ${{ steps.get-tag-version.outputs.minor-ref }}
         PATCH_REF: ${{ steps.get-tag-version.outputs.patch-ref }}
         IS_PRERELEASE: ${{ steps.get-tag-version.outputs.is-prerelease }}
+      shell: bash
 
     - name: BUILD_METHOD | The build method is 'to-prod' for tags
       # This step is run when the branch is a 'v*.*.*' tag
@@ -427,7 +427,6 @@ runs:
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       #if: (github.ref_type == 'tag' && github.event_name=='push')
       if: ${{ steps.get-tag-version.outputs.full-version-ref }}
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-version-full-version-tag' "
         echo ""
@@ -481,6 +480,7 @@ runs:
         echo "::endgroup::"
       env:
         FULL_VERSION_REF: ${{ steps.get-tag-version.outputs.full-version-ref }}
+      shell: bash
 
     - name: BUILD_METHOD | The build method is 'to-prod' for tags (startsWith, on push)
       # This step is run when the branch is a 'v*.*.*' tag
@@ -494,7 +494,6 @@ runs:
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       if: (startsWith(github.ref_name, 'v[0-9][0-9]?.[0-9][0-9]?.[0-9][0-9]?') && github.ref_type == 'tag' && github.event_name=='push' && env.EVAL_BUILD_METHOD=='false')
       #if: (startsWith(github.ref_name, 'v[0-9].[0-9].[0-9]') && github.ref_type == 'tag' && github.event_name=='push' && env.EVAL_BUILD_METHOD=='false')
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-method-prod-startswith' "
         echo ""
@@ -507,6 +506,7 @@ runs:
         echo ""
         echo "completing the 'set-build-method-prod-startswith' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_METHOD | The build method is 'to-prod' for tags (fallback)
       # This step is run when the branch is a 'v*.*.*' tag
@@ -514,7 +514,6 @@ runs:
       #using 'v*.*.*' does not work# #was#if: ${{ contains('refs/tags/v*.*.*', github.ref) && (github.ref_type == 'tag') && (github.event_name=='push') }}
       #using 'v*.*.*' does not work# #if: (startsWith('v*.*.*', github.ref_name) && github.ref_type == 'tag' && env.EVAL_BUILD_METHOD=='false')
       if: (github.ref_type == 'tag' && env.EVAL_BUILD_METHOD=='false')
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-method-prod-fallback' "
         echo ""
@@ -527,12 +526,12 @@ runs:
         echo ""
         echo "completing the 'set-build-method-prod-fallback' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_METHOD | The build method is 'to-main' (startsWith)
       # This step is run when the branch starts with 'main'
       id: set-build-method-main-startswith
       if: (startsWith(github.ref_name, 'main') && env.EVAL_BUILD_METHOD=='false')
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-method-main-startswith' "
         echo ""
@@ -543,6 +542,7 @@ runs:
         echo ""
         echo "completing the 'set-build-method-main-startswith' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_METHOD | The build method is 'to-main' (contains)
       # This step is run when the branch contains 'main'
@@ -553,7 +553,6 @@ runs:
       if: (contains(github.ref_name, 'main') && env.EVAL_BUILD_METHOD=='false')
       # try this next#if: ${{ startsWith(github.ref_name, 'main') && (env.EVAL_BUILD_METHOD=='false') }}
       # try this next#if: ${{ contains(github.ref_name, 'main*') && (env.EVAL_BUILD_METHOD=='false') }}
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-method-main-contains' "
         echo ""
@@ -566,6 +565,7 @@ runs:
         echo ""
         echo "completing the 'set-build-method-main-contains' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_METHOD | The build method is 'to-dev' for pull requests
       id: set-build-method-pull-request
@@ -573,7 +573,6 @@ runs:
       if: (env.EVAL_BUILD_METHOD=='false' && github.event_name=='pull_request')
       # example to delete # startsWith(github.event.pull_request.head.ref, 'dev')
       # example to delete # if: (github.event_name=='pull_request' && env.EVAL_BUILD_METHOD=='false')
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-method-pull-request' "
         echo ""
@@ -584,6 +583,7 @@ runs:
         echo ""
         echo "completing the 'set-build-method-pull-request' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_METHOD | The build method is 'to-dev' for pull requests (endsWith)
       id: set-build-method-pr-endswith
@@ -591,7 +591,6 @@ runs:
       if: (env.EVAL_BUILD_METHOD=='false' && endsWith(github.ref_name, 'merge'))
       # example to delete # startsWith(github.event.pull_request.head.ref, 'dev')
       # example to delete # if: (github.event_name=='pull_request' && env.EVAL_BUILD_METHOD=='false')
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-method-pr-endswith' "
         echo ""
@@ -602,6 +601,7 @@ runs:
         echo ""
         echo "completing the 'set-build-method-pr-endswith' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_METHOD | The build method is 'to-dev' for dev branches (startsWith)
       # This step is run when the branch starts with dev
@@ -609,7 +609,6 @@ runs:
       #was#if: ${{ startsWith(github.ref_name, 'dev') && (env.EVAL_BUILD_METHOD=='false') }}
       # https://docs.github.com/en/actions/learn-github-actions/expressions#startswith
       if: (env.EVAL_BUILD_METHOD=='false' && startsWith(github.ref_name, 'dev'))
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-method-startswith-dev' "
         echo ""
@@ -622,13 +621,13 @@ runs:
         echo ""
         echo "completing the 'set-build-method-startswith-dev' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_METHOD | The build method is 'to-dev' for dev branches (contains)
       # This step is run when the branch is dev
       id: set-build-method-contains-dev
       #was#if: ${{ contains(github.ref_name, 'dev') && (env.EVAL_BUILD_METHOD=='false') }}
       if: (env.EVAL_BUILD_METHOD=='false' && contains(github.ref_name, 'dev'))
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-method-contains-dev' "
         echo ""
@@ -641,13 +640,13 @@ runs:
         echo ""
         echo "completing the 'set-build-method-contains-dev' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_METHOD | The build method is 'to-dev' for test branches (contains)
       # This step is run when the branch is test
       id: set-build-method-contains-test
       #was#if: ${{ contains(github.ref_name, 'test') && (env.EVAL_BUILD_METHOD=='false') }}
       if: (contains(github.ref_name, 'test') && env.EVAL_BUILD_METHOD=='false')
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-method-contains-test' "
         echo ""
@@ -660,12 +659,12 @@ runs:
         echo ""
         echo "completing the 'set-build-method-contains-test' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_METHOD | Fallback value - User input or 'to-dev'
       id: set-build-method-fallback
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
       if: env.EVAL_BUILD_METHOD=='false'
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-method-fallback' "
         echo ""
@@ -703,22 +702,22 @@ runs:
         echo ""
         echo "completing the 'set-build-method-fallback' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: Error if the build method was not set
       id: set-eval-method-error
       if: ${{ env.BUILD_METHOD == '' }}
-      shell: bash
       run: |
         echo "The build method was not set correctly. "
         echo "This workflow will now fail and exit. "
         echo "::error title=⛔ error in the '${{ github.workflow }}' workflow hint::Build method not set correctly "
         exit 1
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+      shell: bash
 
     # Output the build method
     - name: Output the build method
       id: set-method-output
-      shell: bash
       run: |
         echo "::group::starting the 'set-method-output' step ... "
         echo "The BUILD_METHOD has been set to '${{ env.BUILD_METHOD }}' ... "
@@ -748,3 +747,4 @@ runs:
         echo ""
         echo "finishing the 'set-method-output' step ... "
         echo "::endgroup::"
+      shell: bash

--- a/vars/build-type/action.yml
+++ b/vars/build-type/action.yml
@@ -72,15 +72,14 @@ runs:
     - name: Validate that the runner OS is Linux
       if: ${{ runner.os != 'Linux' }}
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
-      shell: bash
       run: |
         echo "error in the action '${{ github.action }}' at file path: '${{ github.action_path }}' "
         echo "::error file=builders/set-type/action.yml,title=⛔ build-type error hint::This action supports Linux only"
         exit 1
+      shell: bash
 
     - name: Greet the triggering_actor
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
-      shell: bash
       run: | 
         echo "Hello ${{ github.triggering_actor }}, the verbose variable is set to true."
         echo ""
@@ -91,13 +90,13 @@ runs:
         echo "  action repo  :  ${{ github.action_repository }} "
         echo "  action status:  ${{ github.action_status }} "
         echo ""
+      shell: bash
 
     - name: Show GitHub runner context
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
       # to do:  run this if either the verbose input is true or the runner.debug is true
       id: show-runner-context
       ## The 'runner.*' and 'RUNNER_*' variables are not available in the WORKFLOW env context or the top-level JOB context, but are available in the STEP env context
-      shell: bash
       env:
         EVAL_GH_VAR_RUNNER_DEBUG_EQ0: ${{ runner.debug == '0' }}
         EVAL_GH_VAR_RUNNER_DEBUG_EQ1: ${{ runner.debug == '1' }}
@@ -142,11 +141,11 @@ runs:
         ##
         echo "::endgroup::"
       ## The 'runner.*' and 'RUNNER_*' variables are not available in the WORKFLOW env context or the top-level JOB context, but are available in the STEP env context
+      shell: bash
 
     - name: Verbose | Print the inputs
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
       id: verbose-print-inputs
-      shell: bash
       run: | 
         echo "::group::starting the 'verbose-print-inputs' step... "
         ## Print the inputs if inputs.verbose=='true'
@@ -169,11 +168,11 @@ runs:
         echo "finishing the 'verbose-print-inputs' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Verbose | Print GitHub Context
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
       id: verbose-github-context
-      shell: bash
       run: | 
         echo "::group::starting the 'verbose-github-context' step... "
         ## Print the inputs if inputs.verbose=='true'
@@ -203,6 +202,7 @@ runs:
         echo "finishing the 'verbose-github-context' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Checkout files from commit tree
       # Verified creator: https://github.com/marketplace/actions/checkout
@@ -227,7 +227,6 @@ runs:
     - name: Extra | The ref_type is 'tag'
       id: extra-ref-type-tag
       if: github.ref_type == 'tag'
-      shell: bash
       run: |
         echo "::group::starting the 'extra-ref-type-tag' step... "
         echo "The ref_type is 'tag' "
@@ -242,6 +241,7 @@ runs:
         echo "finishing the 'extra-ref-type-tag' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Extra | The tag starts with the proper version numbering syntax
       id: extra-tag-with-version-syntax
@@ -252,7 +252,6 @@ runs:
       #    or keep the single digit, but match one or more with `+`:
       #        'v[0-9]+.[0-9]+.[0-9]+'
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      shell: bash
       run: |
         echo "::group::starting the 'extra-tag-with-version-syntax' step... "
         echo "The ref_type is 'tag' and the tag starts with the proper version numbering syntax "
@@ -267,6 +266,7 @@ runs:
         echo "finishing the 'extra-tag-with-version-syntax' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Set environmental variables used to evaluate the build type
       id: set-eval-type-env-vars
@@ -274,7 +274,6 @@ runs:
       #   - 'EVAL_BUILD_TYPE' is set to 'false'
       #   - 'GH_DEFAULT_BRANCH' is set to '${{ github.event.repository.default_branch }}'
       if: ${{ always() }}
-      shell: bash
       run: |
         echo "::group::starting the 'set-eval-type-env-vars' step... "
         echo ""
@@ -285,11 +284,11 @@ runs:
         echo ""
         echo "finishing the 'set-eval-type-env-vars' step... "
         echo "::endgroup::"
+      shell: bash
 
     - name: get-tag-version
       id: get-tag-version
       if: (github.ref_type == 'tag')
-      shell: bash
       run: |
         echo "::group::starting step 'get-tag-version' "
         echo ""
@@ -326,12 +325,12 @@ runs:
         echo ""
         echo "completing the 'get-tag-version' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: get-tag-version | Print outputs
       id: check-get-tag-version
       #if: (github.ref_type == 'tag')
       if: ${{ steps.get-tag-version.outputs.full-version-ref }}
-      shell: bash
       run: |
         echo "::group::starting step 'check-get-tag-version' "
         echo ""
@@ -351,6 +350,7 @@ runs:
         MINOR_REF: ${{ steps.get-tag-version.outputs.minor-ref }}
         PATCH_REF: ${{ steps.get-tag-version.outputs.patch-ref }}
         IS_PRERELEASE: ${{ steps.get-tag-version.outputs.is-prerelease }}
+      shell: bash
 
     - name: BUILD_TYPE | Check for a full version tag, set the build type to prod
       #name: BUILD_TYPE | Check for 'v*.*.*' tags, set the build type to prod
@@ -363,7 +363,6 @@ runs:
       #using 'v*.*.*' does not work# #was#if: ${{ contains('refs/tags/v*.*.*', github.ref) && (github.ref_type == 'tag') && (github.event_name=='push') }}
       #using 'v*.*.*' does not work# #if: (contains('refs/tags/v*.*.*', github.ref) && github.ref_type == 'tag' && github.event_name=='push')
       if: ${{ steps.get-tag-version.outputs.full-version-ref }}
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-type-prod-full-version-tag' "
         echo ""
@@ -402,6 +401,7 @@ runs:
         echo "::endgroup::"
       env:
         FULL_VERSION_REF: ${{ steps.get-tag-version.outputs.full-version-ref }}
+      shell: bash
 
     - name: BUILD_TYPE | Check for 'v*.*.*' tags (fallback), set the build type to prod
       # This step is run when the branch is a 'v*.*.*' tag
@@ -414,7 +414,6 @@ runs:
       if: (github.ref_type == 'tag' && env.EVAL_BUILD_TYPE=='false')
       #try this next#if: (startsWith('refs/tags/v[0-9].[0-9].[0-9]', github.ref) && github.ref_type == 'tag')
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-type-prod-fallback' "
         echo ""
@@ -432,6 +431,7 @@ runs:
         echo ""
         echo "completing the 'set-build-type-prod-fallback' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_TYPE | Check for main branch (contains), set the build type to main
       id: set-eval-type-main-contains
@@ -443,7 +443,6 @@ runs:
       if: (contains(github.ref_name, 'main') && env.EVAL_BUILD_TYPE=='false')
       # try this next#if: ${{ startsWith(github.ref_name, 'main') && (env.EVAL_BUILD_TYPE=='false') }}
       # try this next#if: ${{ contains(github.ref_name, 'main*') && (env.EVAL_BUILD_TYPE=='false') }}
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-type-main-contains' "
         echo ""
@@ -465,6 +464,7 @@ runs:
         echo ""
         echo "completing the 'set-eval-type-main-contains' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_TYPE | Check for main branch (startsWith), set the build type to main
       id: set-eval-type-main-startswith
@@ -475,7 +475,6 @@ runs:
       # does not work#   ${{ contains(github.ref_name, 'main-2.x') && (env.EVAL_BUILD_TYPE=='false') }}
       # does not work# if: ${{ startsWith(github.ref_name, 'main') }} && ${{ env.EVAL_BUILD_TYPE=='false'}}
       if: (startsWith(github.ref_name, 'main') && env.EVAL_BUILD_TYPE=='false')
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-type-main-startswith' "
         echo ""
@@ -489,6 +488,7 @@ runs:
         echo ""
         echo "completing the 'set-eval-type-main-startswith' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_TYPE | Check for 'main-*' branch (contains), set the build type to main
       id: set-eval-type-contains-main-dash
@@ -497,7 +497,6 @@ runs:
       #was#if: ${{ contains('refs/heads/main-*', github.ref) && (env.EVAL_BUILD_TYPE=='false') }}
       if: (contains('main-*', github.ref_name) && env.EVAL_BUILD_TYPE=='false')
       #try next# if: contains('refs/heads/main-*', github.ref) && (env.EVAL_BUILD_TYPE=='false')
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-type-contains-main-dash' "
         echo ""
@@ -511,6 +510,7 @@ runs:
         echo ""
         echo "completing the 'set-eval-type-contains-main-dash' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_TYPE | Check for dev branch (startsWith), set the build type to dev
       id: set-eval-type-dev-startswith
@@ -519,7 +519,6 @@ runs:
       #was#if: ${{ startsWith(github.ref_name, 'dev') && (env.EVAL_BUILD_TYPE=='false') }}
       if: (startsWith(github.ref_name, 'dev') && env.EVAL_BUILD_TYPE=='false')
       #if: env.EVAL_BUILD_TYPE=='false'
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-type-dev-startswith' "
         echo ""
@@ -533,6 +532,7 @@ runs:
         echo ""
         echo "completing the 'set-eval-type-dev-startswith' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_TYPE | Check for 'dev' branch (contains), set the build type to dev
       id: set-eval-type-dev-contains
@@ -540,7 +540,6 @@ runs:
       #was#if: ${{ contains(github.ref_name, 'dev') && (env.EVAL_BUILD_TYPE=='false') }}
       if: (contains(github.ref_name, 'dev') && env.EVAL_BUILD_TYPE=='false')
       #if: env.EVAL_BUILD_TYPE=='false'
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-type-dev-contains' "
         echo ""
@@ -554,6 +553,7 @@ runs:
         echo ""
         echo "completing the 'set-eval-type-dev-contains' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_TYPE | Check for test branch (startsWith), set the build type to test
       id: set-eval-type-test-startswith
@@ -561,7 +561,6 @@ runs:
       #was#if: ${{ startsWith(github.ref_name, 'test') && (env.EVAL_BUILD_TYPE=='false') }}
       if: (startsWith(github.ref_name, 'test') && env.EVAL_BUILD_TYPE=='false')
       #if: env.EVAL_BUILD_TYPE=='false'
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-type-test-startswith' "
         echo ""
@@ -575,6 +574,7 @@ runs:
         echo ""
         echo "completing the 'set-eval-type-test-startswith' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_TYPE | Check for 'test' branch (contains), set the build type to test
       id: set-eval-type-test-contains
@@ -582,7 +582,6 @@ runs:
       #was#if: ${{ contains(github.ref_name, 'test') && (env.EVAL_BUILD_TYPE=='false') }}
       if: (contains(github.ref_name, 'test') && env.EVAL_BUILD_TYPE=='false')
       #if: env.EVAL_BUILD_TYPE=='false'
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-type-test-contains' "
         echo ""
@@ -596,6 +595,7 @@ runs:
         echo ""
         echo "completing the 'set-eval-type-test-contains' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_TYPE | Fallback value - Set the build type to dev
       id: set-eval-type-fallback
@@ -603,7 +603,6 @@ runs:
       #if: github.ref != 'refs/heads/main'
       # If this runs, then that means the previous steps were skipped
       if: env.EVAL_BUILD_TYPE=='false'
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-type-fallback' "
         echo ""
@@ -626,22 +625,22 @@ runs:
         echo ""
         echo "completing the 'set-eval-type-fallback' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: Error if the build type was not set
       id: set-eval-type-error
       if: ${{ env.BUILD_TYPE == '' }}
-      shell: bash
       run: |
         echo "The build type was not set correctly. "
         echo "This workflow will now fail and exit. "
         echo "::error title=⛔ error in the '${{ github.workflow }}' workflow hint::Build type not set correctly "
         exit 1
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+      shell: bash
 
     # Output the build type
     - name: Output the build type
       id: set-type-output
-      shell: bash
       run: |
         echo "::group::starting the 'set-type-output' step ... "
         echo ""
@@ -650,3 +649,4 @@ runs:
         echo ""
         echo "finishing the 'set-type-output' step ... "
         echo "::endgroup::"
+      shell: bash

--- a/vars/build-version/action.yml
+++ b/vars/build-version/action.yml
@@ -70,15 +70,14 @@ runs:
     - name: Validate that the runner OS is Linux
       if: ${{ runner.os != 'Linux' }}
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
-      shell: bash
       run: |
         echo "error in the action '${{ github.action }}' at file path: '${{ github.action_path }}' "
         echo "::error file=builders/set-version/action.yml,title=⛔ build-version error hint::This action supports Linux only"
         exit 1
+      shell: bash
 
     - name: Greet the triggering_actor
       if: inputs.verbose=='true'
-      shell: bash
       run: | 
         echo "Hello ${{ github.triggering_actor }}, the verbose variable is set to true."
         echo ""
@@ -89,13 +88,13 @@ runs:
         echo "  action repo  :  ${{ github.action_repository }} "
         echo "  action status:  ${{ github.action_status }} "
         echo ""
+      shell: bash
 
     - name: Show GitHub runner context
       #if: inputs.verbose=='true'
       # to do:  run this if either the verbose input is true or the runner.debug is true
       id: show-runner-context
       ## The 'runner.*' and 'RUNNER_*' variables are not available in the WORKFLOW env context or the top-level JOB context, but are available in the STEP env context
-      shell: bash
       env:
         EVAL_GH_VAR_RUNNER_DEBUG_EQ0: ${{ runner.debug == '0' }}
         EVAL_GH_VAR_RUNNER_DEBUG_EQ1: ${{ runner.debug == '1' }}
@@ -140,11 +139,11 @@ runs:
         ##
         echo "::endgroup::"
       ## The 'runner.*' and 'RUNNER_*' variables are not available in the WORKFLOW env context or the top-level JOB context, but are available in the STEP env context
+      shell: bash
 
     - name: Verbose | Print the inputs
       if: inputs.verbose=='true'
       id: verbose-print-inputs
-      shell: bash
       run: | 
         echo "::group::starting the 'verbose-print-inputs' step... "
         ## Print the inputs if inputs.verbose=='true'
@@ -166,11 +165,11 @@ runs:
         echo "finishing the 'verbose-print-inputs' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Verbose | Print GitHub Context
       if: inputs.verbose=='true'
       id: verbose-github-context
-      shell: bash
       run: | 
         echo "::group::starting the 'verbose-github-context' step... "
         ## Print the inputs if inputs.verbose=='true'
@@ -200,6 +199,7 @@ runs:
         echo "finishing the 'verbose-github-context' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Checkout files from commit tree
       # Verified creator: https://github.com/marketplace/actions/checkout
@@ -224,7 +224,6 @@ runs:
     - name: Extra | The ref_type is 'tag'
       id: extra-ref-type-tag
       if: github.ref_type == 'tag'
-      shell: bash
       run: |
         echo "::group::starting the 'extra-ref-type-tag' step... "
         echo "The ref_type is 'tag' "
@@ -239,6 +238,7 @@ runs:
         echo "finishing the 'extra-ref-type-tag' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Extra | The tag starts with the proper version numbering syntax
       id: extra-tag-with-version-syntax
@@ -249,7 +249,6 @@ runs:
       #    or keep the single digit, but match one or more with `+`:
       #        'v[0-9]+.[0-9]+.[0-9]+'
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      shell: bash
       run: |
         echo "::group::starting the 'extra-tag-with-version-syntax' step... "
         echo "The ref_type is 'tag' and the tag starts with the proper version numbering syntax "
@@ -264,13 +263,13 @@ runs:
         echo "finishing the 'extra-tag-with-version-syntax' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Fetch the tags from the repo
       id: git-fetch-first
       # error: 'fatal: --unshallow on a complete repository does not make sense'
       #run: "git fetch --force --prune --unshallow --tags"
       # end error for the command above
-      shell: bash
       run: |
         echo "::group::starting the 'git-fetch-first' step... "
         echo ""
@@ -279,6 +278,7 @@ runs:
         git fetch --force --prune --tags
         echo "finishing the 'git-fetch-first' step... "
         echo "::endgroup::"
+      shell: bash
 
     - name: Set environmental variables used to evaluate the build version
       id: set-eval-version-env-vars
@@ -286,7 +286,6 @@ runs:
       #   - 'EVAL_BUILD_VERSION' is set to 'false'
       #   - 'GH_DEFAULT_BRANCH' is set to '${{ github.event.repository.default_branch }}'
       if: ${{ always() }}
-      shell: bash
       run: |
         echo "::group::Setting EVAL_BUILD_VERSION to false..."
         echo "EVAL_BUILD_VERSION=false" >> $GITHUB_ENV
@@ -295,11 +294,11 @@ runs:
         echo ""
         echo "finishing the 'set-eval-version-env-vars' step... "
         echo "::endgroup::"
+      shell: bash
 
     - name: get-tag-version
       id: get-tag-version
       if: (github.ref_type == 'tag')
-      shell: bash
       run: |
         echo "::group::starting step 'get-tag-version' "
         VERSION="${{ github.event.release.tag_name || github.ref_name }}"
@@ -334,12 +333,12 @@ runs:
         echo "is-prerelease=$pre" >> $GITHUB_OUTPUT
         echo "completing the 'get-tag-version' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: get-tag-version | Print outputs
       id: check-get-tag-version
       #if: (github.ref_type == 'tag')
       if: ${{ steps.get-tag-version.outputs.full-version-ref }}
-      shell: bash
       run: |
         echo "::group::starting step 'check-get-tag-version' "
         echo "## get-tag-version outputs"
@@ -358,6 +357,7 @@ runs:
         MINOR_REF: ${{ steps.get-tag-version.outputs.minor-ref }}
         PATCH_REF: ${{ steps.get-tag-version.outputs.patch-ref }}
         IS_PRERELEASE: ${{ steps.get-tag-version.outputs.is-prerelease }}
+      shell: bash
 
     - name: tag-version | Use 'full-version-ref' from 'get-tag-version' to set the build version
       # This step is run when the branch is a 'v*.*.*' tag
@@ -371,7 +371,6 @@ runs:
       #    or keep the single digit, but match one or more with `+`:
       #        'v[0-9]+.[0-9]+.[0-9]+'
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-version-full-version-tag' "
         echo ""
@@ -393,6 +392,7 @@ runs:
         echo "::endgroup::"
       env:
         FULL_VERSION_REF: ${{ steps.get-tag-version.outputs.full-version-ref }}
+      shell: bash
 
     - name: tag-version | Duplicate check for the 'full-version-ref' from 'get-tag-version'
       # This step is run when the branch is a 'v*.*.*' tag
@@ -406,7 +406,6 @@ runs:
       #    or keep the single digit, but match one or more with `+`:
       #        'v[0-9]+.[0-9]+.[0-9]+'
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-version-duplicate-check' "
         echo ""
@@ -443,6 +442,7 @@ runs:
         echo "::endgroup::"
       env:
         FULL_VERSION_REF: ${{ steps.get-tag-version.outputs.full-version-ref }}
+      shell: bash
 
     - name: tag-version | Fallback 1 check for a semver compliant tag to set the build version
       # This step is run when the branch is a 'v*.*.*' tag
@@ -454,7 +454,6 @@ runs:
       #using 'v*.*.*' does not work# #if: ${{ contains('refs/tags/v*.*.*', github.ref) && (github.ref_type == 'tag') && (env.EVAL_BUILD_VERSION=='false') }}
       if: (contains('refs/tags/v[0-9].[0-9].[0-9]', github.ref) && github.ref_type == 'tag' && env.EVAL_BUILD_VERSION=='false')
       #if: {{ github.ref == 'ref/head/v*' }}
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-version-fallback-1-semver-compliant-tag' "
         echo "Setting BUILD_VERSION to '${{ env.FULL_VERSION_REF }}' ..."
@@ -466,6 +465,7 @@ runs:
         echo "::endgroup::"
       env:
         FULL_VERSION_REF: ${{ steps.get-tag-version.outputs.full-version-ref }}
+      shell: bash
 
     - name: tag-version | Fallback 2 check for a semver compliant tag to set the build version
       # This step is run when the branch is a 'v*.*.*' tag
@@ -482,7 +482,6 @@ runs:
       #    or keep the single digit, but match one or more with `+`:
       #        'v[0-9]+.[0-9]+.[0-9]+'
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      shell: bash
       run: |
         echo "::group::starting step 'set-build-version-fallback-2-semver-compliant-tag' "
         echo "Setting BUILD_VERSION to '${{ env.FULL_VERSION_REF }}' ..."
@@ -494,6 +493,7 @@ runs:
         echo "::endgroup::"
       env:
         FULL_VERSION_REF: ${{ steps.get-tag-version.outputs.full-version-ref }}
+      shell: bash
 
     - name: simple-semver | Look for simple semver with git describe
       #name: simple-semver | Look for simple semver with git describe
@@ -507,7 +507,6 @@ runs:
       #        'v[0-9]+.[0-9]+.[0-9]+'
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       if: ${{ always() }}
-      shell: bash
       run: |
         echo "::group::starting the 'simple-semver' step ... "
         if [ '${{ inputs.VERBOSE }}' == 'true' ]; then echo "  verbose - issuing 'set +e' to ignore errors... "; fi
@@ -542,11 +541,11 @@ runs:
         echo "simple-semver=${semver_simple}" >> $GITHUB_OUTPUT
         echo "finishing the 'simple-semver' step ... "
         echo "::endgroup::"
+      shell: bash
 
     - name: simple-semver | Print output
       id: check-simple-semver
       if: ${{ steps.simple-semver.outputs.simple-semver }}
-      shell: bash
       run: |
         echo "::group::starting the 'check-simple-semver' step ... "
         echo "## simple-semver outputs"
@@ -555,11 +554,11 @@ runs:
         echo "::endgroup::"
       env:
         semver_simple: ${{ steps.simple-semver.outputs.simple-semver }}
+      shell: bash
 
     - name: simple-semver | Set the build version using simple-semver output
       id: set-build-version-using-simple-semver
       if: (env.EVAL_BUILD_VERSION=='false' && inputs.strategy=='simple' && ${{ steps.simple-semver.outputs.simple-semver }})
-      shell: bash
       run: |
         echo "::group::starting the 'set-build-version-using-simple-semver' step ... "
         echo ""
@@ -571,6 +570,7 @@ runs:
         echo "::endgroup::"
       env:
         SEMVER_SIMPLE: ${{ steps.simple-semver.outputs.simple-semver }}
+      shell: bash
 
     - name: wildcard-semver | Look for wildcard semver with git describe
       # name: 06a | Run 'git describe --tags --match "v[0-9]*.[0-9]*.[0-9]*"'
@@ -581,7 +581,6 @@ runs:
       #    or keep the single digit, but match one or more with `+`:
       #        'v[0-9]+.[0-9]+.[0-9]+'
       if: (env.EVAL_BUILD_VERSION=='false' || inputs.strategy=='wildcard')
-      shell: bash
       run: |
         echo "::group::starting the 'wildcard-semver' step... "
         ## old wildcard-semver match ##git describe --tags --match "v[0-9]*.[0-9]*.[0-9]*"
@@ -620,11 +619,11 @@ runs:
         echo "wildcard-semver=${semver_wildcard}" >> $GITHUB_OUTPUT
         echo "finishing the 'wildcard-semver' step... "
         echo "::endgroup::"
+      shell: bash
 
     - name: wildcard-semver | Print output
       id: check-wildcard-semver
       if: ${{ steps.wildcard-semver.outputs.wildcard-semver }}
-      shell: bash
       run: |
         echo "::group::starting the 'check-wildcard-semver' step ... "
         echo "## wildcard-semver outputs"
@@ -633,11 +632,11 @@ runs:
         echo "::endgroup::"
       env:
         semver_wildcard: ${{ steps.wildcard-semver.outputs.wildcard-semver }}
+      shell: bash
 
     - name: wildcard-semver | Set the build version using wildcard-semver output
       id: set-build-version-using-wildcard-semver
       if: (env.EVAL_BUILD_VERSION=='false' && inputs.strategy=='wildcard' && ${{ steps.wildcard-semver.outputs.wildcard-semver }})
-      shell: bash
       run: |
         echo "::group::starting the 'set-build-version-using-wildcard-semver' step ... "
         echo ""
@@ -649,6 +648,7 @@ runs:
         echo "::endgroup::"
       env:
         SEMVER_WILDCARD: ${{ steps.wildcard-semver.outputs.wildcard-semver }}
+      shell: bash
 
     - name: Fetch the tags from the repo
       id: git-fetch-second
@@ -656,7 +656,6 @@ runs:
       # error: 'fatal: --unshallow on a complete repository does not make sense'
       #run: "git fetch --force --prune --unshallow --tags"
       # end error for the command above
-      shell: bash
       run: |
         echo "::group::starting the 'git-fetch-second' step... "
         echo ""
@@ -665,12 +664,12 @@ runs:
         git fetch --prune --prune-tags --force --depth=1
         echo "finishing the 'git-fetch-second' step... "
         echo "::endgroup::"
+      shell: bash
 
     - name: BUILD_VERSION | Fallback value using simple-semver output
       # This step is run when the build is not production
       if: (env.EVAL_BUILD_VERSION=='false' || env.BUILD_VERSION == '')
       id: set-fallback-version
-      shell: bash
       run: |
         echo "::group::starting the 'set-fallback-version' step ... "
         ## Compare the simple and wildcard semver versions
@@ -715,6 +714,7 @@ runs:
       env:
         semver_simple: ${{ steps.simple-semver.outputs.simple-semver }}
         semver_wildcard: ${{ steps.wildcard-semver.outputs.wildcard-semver }}
+      shell: bash
 
     - name: TEST | Parse the build version information
       # Parse the build version information when the build is not a 'tag' and the build version is set
@@ -722,7 +722,6 @@ runs:
       if: ${{ env.BUILD_VERSION }} && github.ref_type != 'tag'
       id: parse-build-version-info
       # to do: output the parsed build version information:  major, minor, patch, incre, short
-      shell: bash
       continue-on-error: true
       run: |
         echo "::group::starting the 'parse-build-version-info' step ... "
@@ -804,21 +803,21 @@ runs:
       env:
         semver_simple: ${{ steps.simple-semver.outputs.simple-semver }}
         semver_wildcard: ${{ steps.wildcard-semver.outputs.wildcard-semver }}
+      shell: bash
 
     - name: Error if the build version was not set
       if: ${{ env.BUILD_VERSION == '' }}
-      shell: bash
       run: |
         echo "The build version was not set correctly. "
         echo "This '${{ github.action }}' action at path '${{ github.action_path }}' will now fail and exit. "
         echo "::error file=${{ github.action_path }},title=⛔ '${{ github.action }}' error in the '${{ github.workflow }}' workflow hint::Build version not set correctly "
         exit 1
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+      shell: bash
 
       # Output the build version
     - name: Output the build version
       id: set-version-output
-      shell: bash
       run: |
         echo "::group::starting the 'set-version-output' step ... "
         echo "The BUILD_VERSION has been set to '${{ env.BUILD_VERSION }}' ... "
@@ -833,3 +832,4 @@ runs:
         IS_PRERELEASE: ${{ steps.get-tag-version.outputs.is-prerelease }}
         semver_simple: ${{ steps.simple-semver.outputs.simple-semver }}
         semver_wildcard: ${{ steps.wildcard-semver.outputs.wildcard-semver }}
+      shell: bash

--- a/vars/packer-skip-create/action.yml
+++ b/vars/packer-skip-create/action.yml
@@ -92,15 +92,14 @@ runs:
     - name: Validate that the runner OS is Linux
       if: ${{ runner.os != 'Linux' }}
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
-      shell: bash
       run: |
         echo "error in the action '${{ github.action }}' at file path: '${{ github.action_path }}' "
         echo "::error file=builders/set-skip-create/action.yml,title=⛔ set-skip-create error hint::This action supports Linux only"
         exit 1
+      shell: bash
 
     - name: Greet the triggering_actor
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
-      shell: bash
       run: | 
         echo "Hello ${{ github.triggering_actor }}, the verbose variable is set to true."
         echo ""
@@ -111,13 +110,13 @@ runs:
         echo "  action repo  :  ${{ github.action_repository }} "
         echo "  action status:  ${{ github.action_status }} "
         echo ""
+      shell: bash
 
     - name: Show GitHub runner context
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
       # to do:  run this if either the verbose input is true or the runner.debug is true
       id: show-runner-context
       ## The 'runner.*' and 'RUNNER_*' variables are not available in the WORKFLOW env context or the top-level JOB context, but are available in the STEP env context
-      shell: bash
       env:
         EVAL_GH_VAR_RUNNER_DEBUG_EQ0: ${{ runner.debug == '0' }}
         EVAL_GH_VAR_RUNNER_DEBUG_EQ1: ${{ runner.debug == '1' }}
@@ -162,11 +161,11 @@ runs:
         ##
         echo "::endgroup::"
       ## The 'runner.*' and 'RUNNER_*' variables are not available in the WORKFLOW env context or the top-level JOB context, but are available in the STEP env context
+      shell: bash
 
     - name: Verbose | Print the inputs
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
       id: verbose-print-inputs
-      shell: bash
       run: | 
         echo "::group::starting the 'verbose-print-inputs' step... "
         ## Print the inputs if inputs.verbose=='true'
@@ -190,11 +189,11 @@ runs:
         echo "finishing the 'verbose-print-inputs' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Verbose | Print GitHub Context
       if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
       id: verbose-github-context
-      shell: bash
       run: | 
         echo "::group::starting the 'verbose-github-context' step... "
         ## Print the inputs if inputs.verbose=='true'
@@ -224,6 +223,7 @@ runs:
         echo "finishing the 'verbose-github-context' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     # #     This is not used to set skip-create.
     # - name: Checkout files from commit tree
@@ -250,7 +250,6 @@ runs:
     - name: Extra | The ref_type is 'tag'
       id: extra-ref-type-tag
       if: github.ref_type == 'tag'
-      shell: bash
       run: |
         echo "::group::starting the 'extra-ref-type-tag' step... "
         echo "The ref_type is 'tag' "
@@ -265,6 +264,7 @@ runs:
         echo "finishing the 'extra-ref-type-tag' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Extra | The tag starts with the proper version numbering syntax
       id: extra-tag-with-version-syntax
@@ -275,7 +275,6 @@ runs:
       #    or keep the single digit, but match one or more with `+`:
       #        'v[0-9]+.[0-9]+.[0-9]+'
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      shell: bash
       run: |
         echo "::group::starting the 'extra-tag-with-version-syntax' step... "
         echo "The ref_type is 'tag' and the tag starts with the proper version numbering syntax "
@@ -290,6 +289,7 @@ runs:
         echo "finishing the 'extra-tag-with-version-syntax' step... "
         ##
         echo "::endgroup::"
+      shell: bash
 
     - name: Set environmental variables used to evaluate the build skip-create
       id: set-eval-skip-create-env-vars
@@ -299,7 +299,6 @@ runs:
       #   - 'IMAGE_SKIP_REASON' is set to 'tbd'
       #   - 'GH_DEFAULT_BRANCH' is set to '${{ github.event.repository.default_branch }}'
       if: ${{ always() }}
-      shell: bash
       run: |
         echo "::group::starting the 'set-eval-skip-create-env-vars' step... "
         echo ""
@@ -320,11 +319,11 @@ runs:
         echo ""
         echo "finishing the 'set-eval-skip-create-env-vars' step... "
         echo "::endgroup::"
+      shell: bash
 
     - name: get-tag-version
       id: get-tag-version
       if: (github.ref_type == 'tag')
-      shell: bash
       run: |
         echo "::group::starting step 'get-tag-version' "
         echo ""
@@ -361,12 +360,12 @@ runs:
         echo ""
         echo "completing the 'get-tag-version' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: get-tag-version | Print outputs
       id: check-get-tag-version
       #if: (github.ref_type == 'tag')
       if: ${{ steps.get-tag-version.outputs.full-version-ref }}
-      shell: bash
       run: |
         echo "::group::starting step 'check-get-tag-version' "
         echo ""
@@ -386,6 +385,7 @@ runs:
         MINOR_REF: ${{ steps.get-tag-version.outputs.minor-ref }}
         PATCH_REF: ${{ steps.get-tag-version.outputs.patch-ref }}
         IS_PRERELEASE: ${{ steps.get-tag-version.outputs.is-prerelease }}
+      shell: bash
 
     - name: IMAGE_SKIP_CREATE | Enable image creation for a full version tag
       #name: IMAGE_SKIP_CREATE | Enable image creation for creating (push) a 'v*.*.*' tag
@@ -395,7 +395,6 @@ runs:
       #using 'v*.*.*' does not work#was#if: ${{ contains('refs/tags/v*.*.*', github.ref) && (github.ref_type == 'tag') && (github.event_name=='push') }}
       #using 'v*.*.*' does not work#if: (contains('refs/tags/v*.*.*', github.ref) && github.ref_type == 'tag' && github.event_name=='push')
       if: ${{ steps.get-tag-version.outputs.full-version-ref }}
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-skip-create-full-version-tag' "
         echo ""
@@ -457,13 +456,13 @@ runs:
         echo "::endgroup::"
       env:
         FULL_VERSION_REF: ${{ steps.get-tag-version.outputs.full-version-ref }}
+      shell: bash
 
     - name: IMAGE_SKIP_CREATE | Skip image creation for manual workflow runs
       id: set-eval-skip-create-manual-skip
       # Manual builds where the 'Create an image from build' option is NOT checked
       if: (github.event_name=='workflow_dispatch' && inputs.create-image=='false' && env.EVAL_SKIP_CREATE=='false')
       #try-next#if: env.EVAL_SKIP_CREATE=='false' && (github.event_name=='workflow_dispatch' && inputs.create-image=='false')
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-skip-create-manual-skip' "
         echo ""
@@ -488,13 +487,13 @@ runs:
         echo ""
         echo "completing the 'set-eval-skip-create-manual-skip' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: IMAGE_SKIP_CREATE | Enable image creation for manual workflow runs
       id: set-eval-skip-create-manual-create
       # Manual builds where the 'Create an image from build' option is checked
       if: (github.event_name=='workflow_dispatch' && inputs.create-image=='true' && env.EVAL_SKIP_CREATE=='false')
       #try-next#if: env.EVAL_SKIP_CREATE=='false' && (github.event_name=='workflow_dispatch' && inputs.create-image=='true')
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-skip-create-manual-create' "
         echo ""
@@ -519,6 +518,7 @@ runs:
         echo ""
         echo "completing the 'set-eval-skip-create-manual-create' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: IMAGE_SKIP_CREATE | Skip image creation for scheduled workflow run at ${{ github.event.schedule }}
       id: set-eval-skip-create-scheduled
@@ -527,7 +527,6 @@ runs:
       # do not check the 'env.BUILD_SCHEDULE', only check if `github.event_name=='schedule'`
       if: (github.event_name=='schedule' && env.EVAL_SKIP_CREATE=='false')
       #try-next#if: env.EVAL_SKIP_CREATE=='false' && (github.event_name=='schedule' && github.event.schedule==env.BUILD_SCHEDULE)
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-skip-create-scheduled' "
         echo ""
@@ -553,12 +552,12 @@ runs:
         echo ""
         echo "completing the 'set-eval-skip-create-scheduled' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: IMAGE_SKIP_CREATE | Skip image creation for pull requests
       id: set-eval-skip-create-pull-request
       # Do not create an image when a pull request has been opened
       if: (github.event_name=='pull_request' && env.EVAL_SKIP_CREATE=='false')
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-skip-create-pull-request' "
         echo ""
@@ -598,12 +597,12 @@ runs:
         echo ""
         echo "completing the 'set-eval-skip-create-pull-request' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: IMAGE_SKIP_CREATE | Skip image creation for push (commit) to main
       id: set-eval-skip-create-push-to-main
       # Do not create an image when we push (commit) to main (from a pull request) and the github.ref is 'refs/heads/main'
       # See https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
-      shell: bash
       if: |
         (github.event_name=='push' && github.ref == 'refs/heads/main' && env.EVAL_SKIP_CREATE=='false') || 
         (github.event_name=='push' && startsWith(github.ref_name, 'main') && env.EVAL_SKIP_CREATE=='false')
@@ -640,6 +639,7 @@ runs:
         echo ""
         echo "completing the 'set-eval-skip-create-push-to-main' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: IMAGE_SKIP_CREATE | Skip image creation for push (commit) to default
       id: set-eval-skip-create-push-to-default
@@ -655,7 +655,6 @@ runs:
       #if: (github.event_name=='push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/main-2.x'))
       ## https://stackoverflow.com/questions/68928595/strange-boolean-evaluation-in-github-actions
       ## https://github.com/actions/runner/issues/1173
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-skip-create-push-to-default' "
         echo ""
@@ -703,12 +702,12 @@ runs:
         echo ""
         echo "completing the 'set-eval-skip-create-push-to-default' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: IMAGE_SKIP_CREATE | Fallback value - Skip image creation for other events
       id: set-eval-skip-create-fallback
       # If this runs, then that means the previous steps were skipped
       if: env.EVAL_SKIP_CREATE=='false'
-      shell: bash
       run: |
         echo "::group::starting step 'set-eval-skip-create-fallback' "
         echo ""
@@ -755,17 +754,18 @@ runs:
         echo ""
         echo "completing the 'set-eval-skip-create-fallback' step. "
         echo "::endgroup::"
+      shell: bash
 
     - name: Error if the image skip create variable was not set
       id: set-eval-skip-create-error
       if: ${{ env.IMAGE_SKIP_CREATE == '' }}
-      shell: bash
       run: |
         echo "The image skip create variable was not set. "
         echo "This workflow will now fail and exit. "
         echo "::error title=⛔ error in the '${{ github.workflow }}' workflow hint::Image skip create variable not set correctly. "
         exit 1
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+      shell: bash
 
     - name: Output the image skip create results
       # Output the image skip create results


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request

## Why are you opening this PR?

Move the `shell` option to the end of each step configuration

#### Previous

```yml
      shell: bash
      run: |
        echo "::error title=⛔ error hint::This action supports Linux only"
        exit 1
```

#### New

```yml
      run: |
        echo "::error title=⛔ error hint::This action supports Linux only"
        exit 1
      shell: bash
```

## Related issues
<!--- Are there any related issues? --->
<!--- Please include the URL to the related issue(s). If the PR fixes a bug or resolves a feature request, be sure to link to that issue. --->
**Issue URL(s)**: 
