### PR TITLE
refactor: prefix container image version tags

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -137,8 +137,8 @@ jobs:
             type=ref,priority=600,event=tag
             type=ref,priority=600,event=pr
             type=semver,priority=900,enable=${{ env.IS_REF_TAG }},pattern={{version}}
-            type=semver,priority=900,enable=${{ env.IS_REF_TAG }},pattern={{major}}.{{minor}}
-            type=semver,priority=900,enable=${{ env.IS_REF_TAG }},pattern={{major}}
+            type=semver,priority=900,enable=${{ env.IS_REF_TAG }},pattern=v{{major}}.{{minor}}
+            type=semver,priority=900,enable=${{ env.IS_REF_TAG }},pattern=v{{major}}
           labels: |
             org.opencontainers.image.title=${{ matrix.name }}
             org.opencontainers.image.description=${{ matrix.description }}


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request

## Why are you opening this PR?

Prefix the container image version tags with `v`

## Related issues

**Issue URL(s)**: 
- https://github.com/rwaight/actions/issues/360
- https://github.com/rwaight/actions/issues/361
