### PR TITLE
feat: run action using label checker container

### DIFF
--- a/github/label-checker/action.yml
+++ b/github/label-checker/action.yml
@@ -62,7 +62,12 @@ inputs:
       examples.
     required: false
     default: ''
+
+# runs:
+#   using: 'docker'
+#   image: 'Dockerfile'
+
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "docker://ghcr.io/rwaight/actions/label-checker:v0.2"
 


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request

## Why are you opening this PR?

Run the `github/label-checker` action using the [`actions/label-checker` container](https://github.com/rwaight/actions/pkgs/container/actions%2Flabel-checker)


## Related issues

**Issue URL(s)**:  Closes https://github.com/rwaight/actions/issues/361
