### PR TITLE
feat: build action container images in GHCR or GCPAR (202509 v3)

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -169,6 +169,7 @@ jobs:
             org.opencontainers.image.description=${{ matrix.description }}
             org.opencontainers.image.documentation=https://github.com/${{ github.repository }}/blob/main/${{ matrix.dir }}/README.md
             org.opencontainers.image.revision=${{ steps.get-version.outputs.build-version }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/main/${{ matrix.dir }}
             org.opencontainers.image.version=${{ steps.get-version.outputs.build-version }}
           ##  org.opencontainers.image.version={{version}}

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -67,7 +67,6 @@ jobs:
       GCP_AR_REPO: my-artifact-repo
       #IMAGE_NAME: ${{ github.repository }}
       IMAGE_NAME: ${{ github.repository }}/${{ matrix.name }}
-      #IMAGE_NAME: ${{ matrix.name }}
       IS_REF_TAG: ${{ github.ref_type == 'tag' && 'true' || 'false' }}
     defaults:
       run:

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -84,6 +84,14 @@ jobs:
         #if: env.MY_WORKFLOW_DEBUG=='true'
         run: ls -R
 
+      - name: Get the build version
+        id: get-version
+        uses: rwaight/actions/vars/build-version@main
+        with:
+          checkout: false
+          strategy: 'simple'
+          verbose: ${{ runner.debug == '1' && 'true' || 'false' }}
+
       - name: Setup Go environment
         if: ${{ matrix.go-version }}
         # Verified creator: https://github.com/marketplace/actions/setup-go-environment

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -90,7 +90,7 @@ jobs:
         id: checkout
 
       - name: Display structure of files in working directory
-        #if: env.MY_WORKFLOW_DEBUG=='true'
+        #if: inputs.verbose=='true' || ${{ runner.debug == '1' }}
         run: ls -R
 
       - name: Get the build version

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -168,7 +168,10 @@ jobs:
             org.opencontainers.image.title=${{ matrix.name }}
             org.opencontainers.image.description=${{ matrix.description }}
             org.opencontainers.image.documentation=https://github.com/${{ github.repository }}/blob/main/${{ matrix.dir }}/README.md
+            org.opencontainers.image.revision=${{ steps.get-version.outputs.build-version }}
             org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/main/${{ matrix.dir }}
+            org.opencontainers.image.version=${{ steps.get-version.outputs.build-version }}
+          ##  org.opencontainers.image.version={{version}}
           annotations: |
             org.opencontainers.image.title=${{ matrix.name }}
             org.opencontainers.image.description=${{ matrix.description }}

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -92,6 +92,23 @@ jobs:
           strategy: 'simple'
           verbose: ${{ runner.debug == '1' && 'true' || 'false' }}
 
+      - name: Print build version
+        id: print-build-version
+        if: ${{ steps.get-version.outputs.build-version }}
+        run: |
+          echo "::group::starting step 'print-build-version' "
+          echo ""
+          echo "Output from the 'get-version' step"
+          echo "    build-version: ${{ steps.get-version.outputs.build-version }} "
+          echo ""
+          echo "The output in the 'get-version' step was ${build_version} ."
+          echo ""
+          echo "completing the 'print-build-version' step. "
+          echo "::endgroup::"
+        env:
+          build_version: ${{ steps.get-version.outputs.build-version }}
+        shell: bash
+
       - name: Setup Go environment
         if: ${{ matrix.go-version }}
         # Verified creator: https://github.com/marketplace/actions/setup-go-environment

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           # https://github.com/docker/metadata-action#images-input
           images: |
-            name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},enable=${{ env.IS_GHCR }}
             name=ghcr.io/${{ env.IMAGE_NAME }},enable=${{ env.IS_GHCR }}
             name=${{ env.IMAGE_NAME }},enable=${{ env.IS_GCP_AR }}
             name=${{ env.GCP_AR_REGION }}-docker.pkg.dev/${{ env.GCP_AR_PROJECT }}/${{ env.GCP_AR_REPO }}/${{ env.IMAGE_NAME }},enable=${{ env.IS_GCP_AR }}

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -39,6 +39,8 @@ jobs:
       matrix:
         container: [render-template, pr-label-checker]
         registry: [ghcr.io]
+          # not all containers will be pushed to GCP Artifact Registry
+          #registry: [ghcr.io,gcp]
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-expanding-configurations
         # use 'include' to specify additional variables
         include:
@@ -58,6 +60,11 @@ jobs:
     env:
       REGISTRY: ${{ matrix.registry }}
       IS_GHCR: ${{ matrix.registry == 'ghcr.io' && 'true' || 'false' }}
+      # GCP Artifact Registry
+      IS_GCP_AR: ${{ matrix.registry == 'gcp' && 'true' || 'false' }}
+      GCP_AR_REGION: us-central1
+      GCP_AR_PROJECT: my-gcp-project
+      GCP_AR_REPO: my-artifact-repo
       #IMAGE_NAME: ${{ github.repository }}
       IMAGE_NAME: ${{ github.repository }}/${{ matrix.name }}
       #IMAGE_NAME: ${{ matrix.name }}
@@ -145,6 +152,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         id: docker-login-ghcr
 
+      - name: Login to the GCP Artifact Registry
+        if: matrix.registry == 'gcp'
+        uses: docker/login-action@v3
+        # Verified creator: https://github.com/marketplace/actions/docker-login
+        # GitHub Action to login against a Docker registry
+        with:
+          #registry: us-central1-docker.pkg.dev
+          registry: "${{ env.GCP_AR_REGION }}-docker.pkg.dev"
+          username: _json_key
+          password: ${{ secrets.GCP_BUILD_CONTAINERS_KEY }}
+        id: docker-login-gcp-ar
+
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         # Verified creator: https://github.com/marketplace/actions/docker-metadata-action
@@ -155,6 +174,8 @@ jobs:
           images: |
             name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             name=ghcr.io/${{ env.IMAGE_NAME }},enable=${{ env.IS_GHCR }}
+            name=${{ env.IMAGE_NAME }},enable=${{ env.IS_GCP_AR }}
+            name=${{ env.GCP_AR_REGION }}-docker.pkg.dev/${{ env.GCP_AR_PROJECT }}/${{ env.GCP_AR_REPO }}/${{ env.IMAGE_NAME }},enable=${{ env.IS_GCP_AR }}
           # https://github.com/docker/metadata-action#latest-tag
           # https://github.com/docker/metadata-action#typesha
           # https://github.com/docker/metadata-action#typeref

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -37,17 +37,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        action: [render-template, pr-label-checker]
+        container: [render-template, pr-label-checker]
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-expanding-configurations
         # use 'include' to specify additional variables
         include:
-          - action: render-template
+          - container: render-template
             name: render-template
             description: "Renders file based on template and passed variables"
             dir: utilities/render-template
             go-version: 1.17.x
             #test: "-e DOCKER_TEST_ONLY=true"
-          - action: pr-label-checker
+          - container: pr-label-checker
             name: label-checker
             description: "Checks pull requests for given labels"
             dir: github/label-checker

--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -38,6 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         container: [render-template, pr-label-checker]
+        registry: [ghcr.io]
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-expanding-configurations
         # use 'include' to specify additional variables
         include:
@@ -55,7 +56,8 @@ jobs:
             #test: "-e DOCKER_TEST_ONLY=true"
     # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
     env:
-      REGISTRY: ghcr.io
+      REGISTRY: ${{ matrix.registry }}
+      IS_GHCR: ${{ matrix.registry == 'ghcr.io' && 'true' || 'false' }}
       #IMAGE_NAME: ${{ github.repository }}
       IMAGE_NAME: ${{ github.repository }}/${{ matrix.name }}
       #IMAGE_NAME: ${{ matrix.name }}
@@ -130,19 +132,18 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         id: setup-buildx
 
-      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
-      - name: Log in to the ${{ env.REGISTRY }} container registry
+      - name: Login to the GitHub Container Registry
+        # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+        if: matrix.registry == 'ghcr.io'
         # Verified creator: https://github.com/marketplace/actions/docker-login
         # GitHub Action to login against a Docker registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        #uses: docker/login-action@v3.0.0
         with:
-          #registry: ghcr.io
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           #username: ${{ github.actor }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        id: docker-login
+        id: docker-login-ghcr
 
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
@@ -150,7 +151,10 @@ jobs:
         # GitHub Action to extract metadata (tags, labels) from Git reference and GitHub events for Docker 
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # https://github.com/docker/metadata-action#images-input
+          images: |
+            name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            name=ghcr.io/${{ env.IMAGE_NAME }},enable=${{ env.IS_GHCR }}
           # https://github.com/docker/metadata-action#latest-tag
           # https://github.com/docker/metadata-action#typesha
           # https://github.com/docker/metadata-action#typeref


### PR DESCRIPTION
# GitHub Actions Monorepo - Pull Request

## Why are you opening this PR?

Updates the `build-and-push-containers` workflow to support publishing the actions containers to either the GitHub Container Registry (GHCR) or to the Google Cloud Platform Artifact Registry. 

## Related issues

**Issue URL(s)**: 
- https://github.com/rwaight/actions/issues/360
- https://github.com/rwaight/actions/issues/361
